### PR TITLE
Installs the v2 version of  grommet-cli and grommet library.

### DIFF
--- a/src/screens/Use.js
+++ b/src/screens/Use.js
@@ -43,7 +43,7 @@ class Use extends Component {
             <Heading level={2}>New Application</Heading>
             <Item
               label='grommet cli'
-              snippet={(<code>npm install -g grommet-cli</code>)}
+              snippet={(<code>npm install -g grommet-cli@next</code>)}
               description='Get grommet command line tools on your local environment.'
             />
             <Item

--- a/src/screens/Use.js
+++ b/src/screens/Use.js
@@ -55,7 +55,7 @@ class Use extends Component {
             <Heading level={2}>Existing Application</Heading>
             <Item
               label='grommet library'
-              snippet={(<code>npm install grommet --save</code>)}
+              snippet={(<code>npm install grommet@next --save</code>)}
               description='Get grommet on your local environment.'
             />
             <Item


### PR DESCRIPTION
npm install grommet points to the older version.To install the v2, we
have to use npm install grommet@next.