### PR TITLE
update get started button path on home screen

### DIFF
--- a/src/screens/Home.js
+++ b/src/screens/Home.js
@@ -109,7 +109,7 @@ class Home extends Component {
             </Paragraph>
             <RoutedButton
               a11yTitle='Start reading about components'
-              path='components'
+              path='/components'
               primary={true}
               label='start reading'
             />


### PR DESCRIPTION
Fixes issue #27 by changing the path on the Getting Started `RoutedButton` on the home page from `path='components'` to `path='/components'`