### PR TITLE
Spelling error in Start.js

### DIFF
--- a/src/screens/Home/Start.js
+++ b/src/screens/Home/Start.js
@@ -98,7 +98,7 @@ render(<App />);
             />
             <Anchor
               href="https://github.com/grommet/grommet-starter-existing-app"
-              label={<Text size="large">I have an Exisiting Codebase</Text>}
+              label={<Text size="large">I have an Existing Codebase</Text>}
               icon={<Next />}
               reverse
               target="_blank"


### PR DESCRIPTION
Caught a spelling error on the home page, thought I'd make myself useful and fix it.