### PR TITLE
Update Search.js fix .flat() function undefined error

### DIFF
--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -7,7 +7,7 @@ import { Pusher } from '../Router';
 const allSuggestions = structure.sections
   .map(section => (section.components || []).concat(section.name))
   .concat(structure.externals.map(e => e.name))
-  .flat()
+  .reduce((acc, val) => acc.concat(val), [])
   .sort();
 
 export default class extends Component {


### PR DESCRIPTION
Fixes this error in browser that don't support `.flat()`:
![scrot](https://user-images.githubusercontent.com/3629343/52752009-03c0d300-2fb7-11e9-92e4-5f664dfe2ee9.png)

Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat#reduce_and_concat