### PR TITLE
Fix typo in Text screen

### DIFF
--- a/src/screens/Text.js
+++ b/src/screens/Text.js
@@ -49,6 +49,6 @@ export default () => (
 
 export const TextItem = props => (
   <Item {...props} center>
-    <Text size="large">non-sematic text</Text>
+    <Text size="large">non-semantic text</Text>
   </Item>
 );


### PR DESCRIPTION
`sematic` :arrow_right: `semantic`

As seen on the [components page](https://v2.grommet.io/components#Type)