### PR TITLE
fix override of title on Doc

### DIFF
--- a/src/components/Doc/Doc.js
+++ b/src/components/Doc/Doc.js
@@ -14,9 +14,9 @@ class Doc extends Component {
   state = {};
 
   componentDidMount() {
-    const { name, nav } = this.props;
+    const { name, nav, title } = this.props;
     if (nav) {
-      document.title = `${name} - Grommet`;
+      document.title = `${title || name} - Grommet`;
       window.scrollTo(0, 0);
     }
   }

--- a/src/screens/Accordion.js
+++ b/src/screens/Accordion.js
@@ -45,6 +45,7 @@ export default () => (
       nav={false}
       desc={descAccordionPanel}
       themeDoc={themeDoc}
+      title="Accordion"
       syntaxes={{
         'accordion.icons.collapse': '<UpIcon />',
         'accordion.icons.expand': '<DownIcon />',

--- a/src/screens/Chart.js
+++ b/src/screens/Chart.js
@@ -71,7 +71,7 @@ export default () => (
       }}
     />
 
-    <Doc name="calcs" nav={false} desc={descCalcs} />
+    <Doc title="Chart" name="calcs" nav={false} desc={descCalcs} />
   </Page>
 );
 

--- a/src/screens/Table.js
+++ b/src/screens/Table.js
@@ -66,7 +66,7 @@ export default () => (
 
     <Doc name="TableHeader" nav={false} desc={descTableHeader} />
     <Doc name="TableBody" nav={false} desc={descTableBody} />
-    <Doc name="TableFooter" nav={false} desc={descTableFooter} />
+    <Doc name="TableFooter" nav={false} title="Table" desc={descTableFooter} />
   </Page>
 );
 

--- a/src/screens/Tabs.js
+++ b/src/screens/Tabs.js
@@ -44,6 +44,7 @@ export default () => (
       name="Tab"
       desc={descTab}
       nav={false}
+      title="Tabs"
       syntaxes={{
         title: ['Tab Title', '<Box>...</Box>'],
       }}


### PR DESCRIPTION
I noticed that whenever there is more than one `Doc` component listed in the Grommet components, the document.title is being overridden. 

I allowed Doc to accept the prop `title` so the title can be set to an explicit title if needed.
This issue reproduces for Accordion, Chart, Tabs & Table.

example of the problem:
<img width="1372" alt="Screen Shot 2019-03-12 at 6 58 13 PM" src="https://user-images.githubusercontent.com/6320236/54246086-0b619200-44f9-11e9-81a5-cd475eead248.png">
