### PR TITLE
fix: add scroll position reset to route changes

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -43,6 +43,7 @@ export class Router extends Component {
           `${nextPath}${search || ''}`,
         );
         this.setState({ path: nextPath });
+        window.scrollTo(0, 0);
       }
     }
   };


### PR DESCRIPTION
Currently when route changes scroll position doesn't
reset. As a result when a user reaches to bottom of
a page & changes route, the most important part of
next route is not immediately visible. With scroll
reset on route changes, user sees the top of next route
first.

Fixes #106