### PR TITLE
Fix defaultValue display for 'number' prop-type 

### DIFF
--- a/src/components/Doc/Value.js
+++ b/src/components/Doc/Value.js
@@ -27,13 +27,13 @@ const Values = ({ name, values, defaultValue }) => {
             (defaultValue === false && valueContent === 'false');
           if (
             values.length === 1 &&
-            valueContent === 'string' &&
-            defaultValue
+            (valueContent === 'string' || valueContent === 'number') &&
+            defaultValue !== undefined
           ) {
             valueContent = defaultValue;
             isDefault = true;
           }
-          if (value !== 'true' && value !== 'false') {
+          if (value !== 'true' && value !== 'false' && value !== 'number') {
             valueContent = `"${valueContent}"`;
           }
           if (isDefault) {


### PR DESCRIPTION
In case prop type is a number, the site isn't displaying the defaultValue.

This fix is displaying the defaultValue when the prop type is a number.

See the following examples for reference/testing:

InfiniteScroll-> step should show default value of 50. https://v2.grommet.io/infinitescroll#step

RangeSelector -> max or min props should show actual values.
 https://v2.grommet.io/rangeselector#max
 https://v2.grommet.io/rangeselector#min
 https://v2.grommet.io/rangeselector#step

