### PR TITLE
It was not clear from docs that label is an option

### DIFF
--- a/src/screens/RadioButtonGroup.js
+++ b/src/screens/RadioButtonGroup.js
@@ -28,7 +28,15 @@ export default () => (
       syntaxes={{
         options: [
           ['string'],
-          [{ disabled: false, id: 'ONE', name: 'one', value: '1' }],
+          [
+            {
+              disabled: false,
+              id: 'ONE',
+              name: 'one',
+              value: '1',
+              label: 'one',
+            },
+          ],
         ],
       }}
     />


### PR DESCRIPTION
https://github.com/grommet/grommet/issues/3306

See original Issue 

An issue in Grommet docs came up that label was not clear that it can also be an option for the RadioButtonGroup. 