### PR TITLE
Adjust phrasing on docs page

### DIFF
--- a/src/screens/Docs/index.js
+++ b/src/screens/Docs/index.js
@@ -18,7 +18,7 @@ export default () => (
   <Page>
     <MarkdownTemplate
       name="Docs"
-      desc="you got questions, we got some answers. something missing, hit us up on [slack](https://slackin.grommet.io/), or open an [issue](https://github.com/grommet/grommet/issues)."
+      desc="you got questions, we got some answers. something missing? hit us up on [slack](https://slackin.grommet.io/), or open an [issue](https://github.com/grommet/grommet/issues)."
     >
       {content}
     </MarkdownTemplate>


### PR DESCRIPTION
The existing phrasing seems like it was a list of three items as opposed to a question and response. This makes it more clear upon skimming that it's question and then 2 links as answers.