### PR TITLE
Responsive context docs

### DIFF
--- a/src/screens/Docs/index.js
+++ b/src/screens/Docs/index.js
@@ -18,7 +18,7 @@ export default () => (
   <Page>
     <MarkdownTemplate
       name="Docs"
-      desc="you got questions, we got some answers. something missing, hit us up on [slack](https://slackin.grommet.io/), or open an [issue](https://github.com/grommet/grommet/issues)."
+      desc="you got questions, we got some answers. something missing? hit us up on [slack](https://slackin.grommet.io/), or open an [issue](https://github.com/grommet/grommet/issues)."
     >
       {content}
     </MarkdownTemplate>

--- a/src/screens/ResponsiveContext.js
+++ b/src/screens/ResponsiveContext.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Box } from 'grommet';
 import { ResponsiveContext } from 'grommet/contexts';
-import { doc } from 'grommet/contexts/ResponsiveContext/doc';
+import { doc, themeDoc } from 'grommet/contexts/ResponsiveContext/doc';
 
 import Page from '../components/Page';
 import Doc from '../components/Doc';
@@ -16,6 +16,7 @@ export default () => (
       name="ResponsiveContext"
       title="Responsive Context .Consumer"
       desc={desc}
+      themeDoc={themeDoc}
       code={`<ResponsiveContext.Consumer>
   {(size) => (
     <Box pad="medium">


### PR DESCRIPTION
Responsive Context had theme docs that were not displaying. This PR allows any theme docs to be displayed.

Local testing has been done to see that this change does display theme docs.