### PR TITLE
Update Accordion Panel and Calc Titles

### DIFF
--- a/src/screens/Accordion.js
+++ b/src/screens/Accordion.js
@@ -45,7 +45,7 @@ export default () => (
       nav={false}
       desc={descAccordionPanel}
       themeDoc={themeDoc}
-      title="Accordion"
+      title="Accordion Panel"
       syntaxes={{
         'accordion.icons.collapse': '<UpIcon />',
         'accordion.icons.expand': '<DownIcon />',

--- a/src/screens/Chart.js
+++ b/src/screens/Chart.js
@@ -71,7 +71,7 @@ export default () => (
       }}
     />
 
-    <Doc title="Chart" name="calcs" nav={false} desc={descCalcs} />
+    <Doc title="Calc" name="calcs" nav={false} desc={descCalcs} />
   </Page>
 );
 

--- a/src/screens/Docs/index.js
+++ b/src/screens/Docs/index.js
@@ -18,7 +18,7 @@ export default () => (
   <Page>
     <MarkdownTemplate
       name="Docs"
-      desc="you got questions, we got some answers. something missing, hit us up on [slack](https://slackin.grommet.io/), or open an [issue](https://github.com/grommet/grommet/issues)."
+      desc="you got questions, we got some answers. something missing? hit us up on [slack](https://slackin.grommet.io/), or open an [issue](https://github.com/grommet/grommet/issues)."
     >
       {content}
     </MarkdownTemplate>

--- a/src/screens/Tabs.js
+++ b/src/screens/Tabs.js
@@ -44,7 +44,7 @@ export default () => (
       name="Tab"
       desc={descTab}
       nav={false}
-      title="Tabs"
+      title="Tab"
       syntaxes={{
         title: ['Tab Title', '<Box>...</Box>'],
       }}


### PR DESCRIPTION
This PR resolves the issue noted in Issue #122. Chart has a second item that needed to be labeled "Calc" and Accordion has a second item that needed to be labeled "Accordion Panel".