### PR TITLE
Add padding to component code box for tooltip visibility

### DIFF
--- a/src/components/Doc/Code.js
+++ b/src/components/Doc/Code.js
@@ -91,7 +91,7 @@ export const Code = ({ code: propsCode, name }) => {
               border={{ side: 'left', color: 'brand' }}
               pad={{ vertical: 'small', right: 'small' }}
             >
-              <Box height={editorHeight}>
+              <Box height={editorHeight} pad={{ vertical: 'medium' }}>
                 <MonacoEditor
                   theme="vs-light"
                   language="javascript"


### PR DESCRIPTION
The editor inside the components pages has its tooltip cut off on the first line of code.

![Screenshot at Dec 11 15-44-07](https://user-images.githubusercontent.com/1981296/70670116-074fd580-1c2d-11ea-9b18-3fc48b455480.png)

This PR proposes a fix by adding vertical padding to the encompassing Box element.

![Screenshot at Dec 11 15-42-58](https://user-images.githubusercontent.com/1981296/70670053-e5eee980-1c2c-11ea-9254-3a644ef66cd5.png)

