### PR TITLE
MonacoEditor tooltips get cut off inside their Box 

### DIFF
--- a/src/components/Doc/Code.js
+++ b/src/components/Doc/Code.js
@@ -77,7 +77,6 @@ export const Code = ({ code: propsCode, name }) => {
       margin={{ top: 'large' }}
       border={{ color: 'brand' }}
       round
-      overflow="hidden"
     >
       <LiveProvider code={code} scope={scope}>
         <Box direction="row-responsive">


### PR DESCRIPTION
MonacoEditor provides tooltip explanations for hovering over various components and attributes in the code.
The tooltip gets cut off from the top due to the hidden overflow attribute applied to the parent Box.

Removing the overflow attribute does not appear to effect anything else inside the box.

<img width="673" alt="Screenshot at Dec 11 18-42-44" src="https://user-images.githubusercontent.com/1981296/70679570-640db900-1c4a-11ea-9f69-60dc1e8bd3be.png">


<img width="653" alt="Screenshot at Dec 11 18-42-15" src="https://user-images.githubusercontent.com/1981296/70679576-66701300-1c4a-11ea-86fe-a384c376e4c1.png">
