### PR TITLE
add to checkboxgroup and radiobuttongroup docs

### DIFF
--- a/src/screens/CheckBoxGroup.js
+++ b/src/screens/CheckBoxGroup.js
@@ -20,6 +20,13 @@ export default () => (
     <CheckBoxGroup options={["Maui", "Kauai", "Oahu"]} />
   </Box>
 </Grommet>`}
+      isA={{
+        base: 'Box',
+        path: '/box',
+        defaultProps: {
+          gap: 'small',
+        },
+      }}
       syntaxes={{
         ...genericSyntaxes,
         onChange: ['({ value, option }) => {...}'],

--- a/src/screens/RadioButtonGroup.js
+++ b/src/screens/RadioButtonGroup.js
@@ -25,6 +25,13 @@ export default () => (
     />
   );
 }`}
+      isA={{
+        base: 'Box',
+        path: '/box',
+        defaultProps: {
+          gap: 'small',
+        },
+      }}
       syntaxes={{
         children: ['(option, { checked, hover }) => {...}'],
         onChange: ['({ target: { value } }) => {...}'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1744,9 +1744,9 @@
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
 "@types/glob@^7.1.1":
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.2.tgz#06ca26521353a545d94a0adc74f38a59d232c987"
-  integrity sha512-VgNIkxK+j7Nz5P7jvUZlRvhuPSmsEfS03b0alKcq5V/STUKAa3Plemsn5mrQUO7am6OErJ4rhGEGJbACclrtRA==
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"
+  integrity sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==
   dependencies:
     "@types/minimatch" "*"
     "@types/node" "*"
@@ -1782,9 +1782,9 @@
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
 "@types/node@*":
-  version "14.0.14"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.14.tgz#24a0b5959f16ac141aeb0c5b3cd7a15b7c64cbce"
-  integrity sha512-syUgf67ZQpaJj01/tRTknkMNoBBLWJOBODF0Zm4NrXmiSuxjymFrxnTu1QVYRubhVkRcZLYZG8STTwJRdVm/WQ==
+  version "14.0.18"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.18.tgz#5111b2285659442f9f95697386a2b42b875bd7e9"
+  integrity sha512-0Z3nS5acM0cIV4JPzrj9g/GH0Et5vmADWtip3YOXOp1NpOLU8V3KoZDc8ny9c1pe/YSYYzQkAWob6dyV/EWg4g==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -1856,9 +1856,9 @@
     source-map "^0.7.3"
 
 "@types/webpack@^4.4.19", "@types/webpack@^4.4.31", "@types/webpack@^4.41.8":
-  version "4.41.19"
-  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.19.tgz#fbcacda7b6061f0e1ba0132a8617a0df89345d41"
-  integrity sha512-hBryCwAJhqf7MiYNnsr6UsPVQHF4+sUnXVG9MTVAJFtX8vJoxc2rPFcWEAUVuBOCxfTkEY5TPc7RYUer7EXTEQ==
+  version "4.41.20"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.20.tgz#aceaa606240d6897d88d70bcb9ff0e61bd691f4c"
+  integrity sha512-MBHtjttd1NTrrr3m+De5VAlnNHgkdK79Kd0zAjVpFPPOSXri+3oA9q8VvC7SDPITzaWiSS1whBrGLtN2HodM5w==
   dependencies:
     "@types/anymatch" "*"
     "@types/node" "*"
@@ -4432,9 +4432,9 @@ ejs@^2.3.4, ejs@^2.6.1:
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
 electron-to-chromium@^1.3.247, electron-to-chromium@^1.3.488:
-  version "1.3.488"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.488.tgz#9226229f5fbc825959210e81e0bb3e63035d1c06"
-  integrity sha512-NReBdOugu1yl8ly+0VDtiQ6Yw/1sLjnvflWq0gvY1nfUXU2PbA+1XAVuEb7ModnwL/MfUPjby7e4pAFnSHiy6Q==
+  version "1.3.490"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.490.tgz#12aa776c493e66ba21536512fc317bdda6d04cd4"
+  integrity sha512-jKJF1mKXrQkT0ZiuJ/oV63Q02hAeWz0GGt/z6ryc518uCHtMyS9+wYAysZtBQ8rsjqFPAYXV4TIz5GQ8xyubPA==
 
 element-resize-detector@^1.2.1:
   version "1.2.1"
@@ -5710,7 +5710,7 @@ grommet-theme-v1@^0.1.2:
 
 "grommet@https://github.com/grommet/grommet/tarball/stable":
   version "2.14.0"
-  resolved "https://github.com/grommet/grommet/tarball/stable#860f8a8c0f0121df0a399a8c00858caf7ecf0dd6"
+  resolved "https://github.com/grommet/grommet/tarball/stable#d0d2d2203c72c77746928b2ecf134db7ce98d790"
   dependencies:
     grommet-icons "^4.2.0"
     hoist-non-react-statics "^3.2.0"


### PR DESCRIPTION
Closes issue #4183 in grommet 

`RadioButtonGroup` and `CheckBoxGroup` are both made from boxes these both have a default gap that is being used. Users can change this so documentation was needed here to let users know that the gap was being set but can be changed. 

https://github.com/grommet/grommet/blob/master/src/js/components/CheckBoxGroup/CheckBoxGroup.js#L12

This is the case for both components.
Preview of what page will look like: 

<img width="1148" alt="Screen Shot 2020-07-07 at 11 02 53 AM" src="https://user-images.githubusercontent.com/42451602/86816722-69e14680-c041-11ea-9377-50f7006dd2ae.png">
