### PR TITLE
Add a link to Github repo in the header

### DIFF
--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Box, Text, ResponsiveContext } from 'grommet';
-import { Grommet as GrommetIcon } from 'grommet-icons';
+import { Box, Button, Text, ResponsiveContext } from 'grommet';
+import { Github, Grommet as GrommetIcon } from 'grommet-icons';
 import RoutedAnchor from './RoutedAnchor';
 import RoutedButton from './RoutedButton';
 import Search from './Search';
@@ -23,7 +23,13 @@ export default () => {
         icon={<GrommetIcon size="large" />}
         label={size !== 'small' && <Text size="xlarge">grommet</Text>}
       />
-      <Box direction="row" gap="small">
+      <Box align="center" direction="row" gap="small">
+        <Button
+          a11yTitle="Go to grommet on GitHub"
+          target="_blank"
+          href="https://github.com/grommet/grommet"
+          icon={<Github color="brand" size="large" />}
+        />
         {!searchOpen && (
           <RoutedButton path="/components" plain>
             {({ hover }) => (


### PR DESCRIPTION
# Problem

Once you leave the homepage, and even there, it is not so easy to get to the github repo from the website. On every documentation page, there is a link to Storybook and the Codesandox, but getting to the source code is more challenging than it should be. This PR adds a Github link to the header.

Adding the icon to the header was not my initial solution. I thought it would be better to add a "Repository" anchor that would navigate directly to each component's source code in the same way the Storybook and Codesandbox links use the  `getAvailableAtBadge` function. Unfortunately, the URLs are not as clean to generate across all the components and utilities, but maybe this is something that could be given more thought in the future.

# Solution

![Screen Shot 2021-06-15 at 10 52 28 AM](https://user-images.githubusercontent.com/919738/122075127-d2938000-cdc7-11eb-8e84-692f38f6dcf0.png)
