### PR TITLE
Updated Box doc to new format

### DIFF
--- a/src/components/Doc/PropExample.js
+++ b/src/components/Doc/PropExample.js
@@ -5,7 +5,9 @@ import { Text } from 'grommet';
 export const Example = ({ children, defaultValue }) => {
   return (
     <Text color="neutral-1" weight={defaultValue === true ? 'bold' : 'normal'}>
-      {children}
+      <pre style={{ margin: 0, font: 'inherit', whiteSpace: 'pre-wrap' }}>
+        {children}
+      </pre>
     </Text>
   );
 };

--- a/src/components/Doc/PropOptions.js
+++ b/src/components/Doc/PropOptions.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Box, Text } from 'grommet';
+
+export const PropOptions = ({ children, prop }) => {
+  return (
+    <Box margin={{ top: 'small' }}>
+      <Text color="dark-3">{`where ${prop} could be:`}</Text>
+      <Box margin={{ left: 'medium' }}>{children}</Box>
+    </Box>
+  );
+};
+
+PropOptions.displayName = 'PropOptions';
+
+PropOptions.propTypes = {
+  children: PropTypes.node,
+  prop: PropTypes.string,
+};
+
+PropOptions.defaultProps = {
+  children: undefined,
+  prop: undefined,
+};

--- a/src/components/Doc/index.js
+++ b/src/components/Doc/index.js
@@ -7,3 +7,4 @@ export { Property } from './Property';
 export { PropertyValue } from './PropertyValue';
 export { Example } from './PropExample';
 export { ThemeDoc } from './ThemeDoc';
+export { PropOptions } from './PropOptions';

--- a/src/screens/Accordion.js
+++ b/src/screens/Accordion.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Markdown } from 'grommet';
+import { Box } from 'grommet';
 import Page from '../components/Page';
 import Item from './Components/Item';
 import {
@@ -41,17 +41,18 @@ export default () => (
       description="An accordion containing collapsible panels."
       intrinsicElement="div"
       code={`<Accordion>
-      <AccordionPanel label="Panel 1">
-        <Box pad="medium" background="light-2">
-          <Text>One</Text>
-        </Box>
-      </AccordionPanel>
-      <AccordionPanel label="Panel 2">
-        <Box pad="medium" background="light-2">
-          <Text>Two</Text>
-        </Box>
-      </AccordionPanel>
-    </Accordion>`}
+  <AccordionPanel label="Panel 1">
+    <Box pad="medium" background="light-2">
+      <Text>One</Text>
+    </Box>
+  </AccordionPanel>
+  <AccordionPanel label="Panel 2">
+    <Box pad="medium" background="light-2">
+      <Text>Two</Text>
+    </Box>
+  </AccordionPanel>
+</Accordion>
+    `}
     >
       <Properties>
         <Property name="a11yTitle">
@@ -59,9 +60,7 @@ export default () => (
             Custom label to be used by screen readers. When provided, an
             aria-label will be added to the element.
           </Description>
-          <PropertyValue type="string">
-            <GenericA11yTitle />
-          </PropertyValue>
+          <GenericA11yTitle />
         </Property>
 
         <Property name="alignSelf">
@@ -69,18 +68,14 @@ export default () => (
             How to align along the cross axis when contained in a Box or along
             the column axis when contained in a Grid.
           </Description>
-          <PropertyValue type="string">
-            <GenericAlignSelf />
-          </PropertyValue>
+          <GenericAlignSelf />
         </Property>
 
         <Property name="gridArea">
           <Description>
             The name of the area to place this inside a parent Grid.
           </Description>
-          <PropertyValue type="string">
-            <GenericGridArea />
-          </PropertyValue>
+          <GenericGridArea />
         </Property>
 
         <Property name="margin">
@@ -145,13 +140,11 @@ export default () => (
           </Description>
           <PropertyValue type="object">
             <Example defaultValue>
-              <Markdown>
-                {`
-    {
-      tabContents: "Tab Contents"
-    }
+              {`
+{
+  tabContents: "Tab Contents"
+}
             `}
-              </Markdown>
             </Example>
           </PropertyValue>
         </Property>

--- a/src/screens/Anchor.js
+++ b/src/screens/Anchor.js
@@ -47,9 +47,7 @@ export default () => (
       <Properties>
         <Property name="a11yTitle">
           <Description>Custom title to be used by screen readers.</Description>
-          <PropertyValue type="string">
-            <GenericA11yTitle />
-          </PropertyValue>
+          <GenericA11yTitle />
         </Property>
 
         <Property name="alignSelf">
@@ -57,18 +55,14 @@ export default () => (
             How to align along the cross axis when contained in a Box or along
             the column axis when contained in a Grid.
           </Description>
-          <PropertyValue type="string">
-            <GenericAlignSelf />
-          </PropertyValue>
+          <GenericAlignSelf />
         </Property>
 
         <Property name="gridArea">
           <Description>
             The name of the area to place this inside a parent Grid.
           </Description>
-          <PropertyValue type="string">
-            <GenericGridArea />
-          </PropertyValue>
+          <GenericGridArea />
         </Property>
 
         <Property name="margin">

--- a/src/screens/Box.js
+++ b/src/screens/Box.js
@@ -97,9 +97,7 @@ export default () => (
 
         <Property name="margin">
           <Description>
-            The amount of margin around the component. An object can be
-            specified to distinguish horizontal margin, vertical margin, and
-            margin on a particular side.
+            The amount of margin around the component.
           </Description>
           <GenericMargin />
         </Property>

--- a/src/screens/Box.js
+++ b/src/screens/Box.js
@@ -1,18 +1,67 @@
 import React from 'react';
 import { Box } from 'grommet';
-import { doc, themeDoc } from 'grommet/components/Box/doc';
 import Page from '../components/Page';
-import Doc from '../components/Doc';
-import { genericSyntaxes } from '../utils/props';
 import Item from './Components/Item';
 
-const desc = doc(Box).toJSON();
+import {
+  GenericA11yTitle,
+  GenericAlign,
+  GenericAlignSelf,
+  GenericAs,
+  GenericBool,
+  GenericBoolTrue,
+  GenericBoolFalse,
+  GenericElevation,
+  GenericFill,
+  GenericGridArea,
+  GenericMargin,
+  GenericPad,
+  SizesXsmallXlarge,
+} from '../utils/genericPropExamples';
+import {
+  GenericExtend,
+  GlobalAnimation,
+  GlobalBorderSize,
+  GlobalElevation,
+  GlobalColorsBorder,
+  GlobalHoverBackgroundColor,
+  GlobalHoverBackgroundOpacity,
+  GlobalHoverColor,
+  GlobalEdgeSize,
+  GlobalBreakpoints,
+} from '../utils/genericThemeExamples';
+import {
+  ComponentDoc,
+  Properties,
+  Property,
+  PropertyValue,
+  Description,
+  Example,
+  ThemeDoc,
+  PropOptions,
+} from '../components/Doc';
 
 export default () => (
   <Page>
-    <Doc
+    <ComponentDoc
       name="Box"
-      desc={desc}
+      availableAt={[
+        {
+          url:
+            'https://storybook.grommet.io/?selectedKind=Layout-Box&full=0&stories=1&panelRight=0',
+          badge:
+            'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
+          label: 'Storybook',
+        },
+        {
+          url:
+            'https://codesandbox.io/s/github/grommet/grommet-sandbox?initialpath=/box&module=%2Fsrc%2FBox.js',
+          badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
+          label: 'CodeSandbox',
+        },
+      ]}
+      description="A container that lays out its contents in one direction"
+      intrinsicElement="div"
       code={`<Box
   direction="row"
   border={{ color: 'brand', size: 'large' }}
@@ -21,237 +70,637 @@ export default () => (
   <Box pad="small" background="dark-3" />
   <Box pad="medium" background="light-3" />
 </Box>`}
-      syntaxes={{
-        ...genericSyntaxes,
-        align: ['start', 'center', 'end', 'baseline', 'stretch'],
-        alignContent: [
-          'start',
-          'center',
-          'end',
-          'between',
-          'around',
-          'stretch',
-        ],
-        animation: [
-          'fadeIn',
-          'fadeOut',
-          'jiggle',
-          'pulse',
-          'rotateRight',
-          'rotateLeft',
-          'slideUp',
-          'slideDown',
-          'slideLeft',
-          'slideRight',
-          'zoomIn',
-          'zoomOut',
-          {
-            type: '...',
-            delay: 0,
-            duration: 1000,
-            size: 'xsmall',
-          },
-          ['fadeIn', 'slideDown', '...'],
-        ],
-        background: [
-          'neutral-1',
-          'url(//my.com/assets/img.png)',
-          {
-            color: 'neutral-1',
-            dark: true,
-            opacity: true,
-            position: 'bottom',
-            repeat: 'no-repeat',
-            size: 'cover',
-            image: 'url(//my.com/assets/img.png)',
-          },
-          {
-            dark: 'light-2',
-            light: 'dark-2',
-          },
-          {
-            VALUES: {
-              opacity: ['weak', 'medium', 'strong', true],
-              position: 'any CSS for background-position',
-              repeat: ['no-repeat', 'repeat', 'string'],
-              size: ['cover', 'contain', 'string'],
-            },
-          },
-        ],
-        basis: [
-          'xxsmall',
-          'xsmall',
-          'small',
-          'medium',
-          'large',
-          'xlarge',
-          'full',
-          '1/2',
-          '1/3',
-          '2/3',
-          '1/4',
-          '2/4',
-          '3/4',
-          'auto',
-        ],
-        border: [
-          true,
-          false,
-          'top',
-          'left',
-          'bottom',
-          'right',
-          'between',
-          'horizontal',
-          'vertical',
-          'all',
-          {
-            color: 'border',
-            size: 'medium',
-            style: 'dashed',
-            side: 'all',
-          },
-          {
-            VALUES: {
-              size: [
-                'xsmall',
-                'small',
-                'medium',
-                'large',
-                'xlarge',
-                'any CSS size',
-              ],
-              style: [
-                'solid',
-                'dashed',
-                'dotted',
-                'double',
-                'groove',
-                'ridge',
-                'inset',
-                'outset',
-                'hidden',
-              ],
-              side: [
-                'top',
-                'left',
-                'bottom',
-                'right',
-                'horizontal',
-                'vertical',
-                'all',
-              ],
-            },
-          },
-        ],
-        elevation: [
-          'none',
-          'xsmall',
-          'small',
-          'medium',
-          'large',
-          'xlarge',
-          'any custom elevation name in the current theme',
-        ],
-        gap: [
-          'none',
-          'xxsmall',
-          'xsmall',
-          'small',
-          'medium',
-          'large',
-          'xlarge',
-          'any CSS size',
-        ],
-        height: [
-          'xxsmall',
-          'xsmall',
-          'small',
-          'medium',
-          'large',
-          'xlarge',
-          'xxlarge',
-          {
-            min: '...',
-            max: '...',
-          },
-          'any CSS size',
-        ],
-        overflow: [
-          'auto',
-          'hidden',
-          'scroll',
-          'visible',
-          'any CSS overflow',
-          {
-            vertical: '...',
-            horizontal: '...',
-          },
-        ],
-        pad: [
-          'none',
-          'xxsmall',
-          'xsmall',
-          'small',
-          'medium',
-          'large',
-          'xlarge',
-          'any CSS size',
-          {
-            vertical: '...',
-            horizontal: '...',
-            top: '...',
-            bottom: '...',
-            left: '...',
-            right: '...',
-          },
-        ],
-        round: [
-          true,
-          false,
-          'xsmall',
-          'small',
-          'medium',
-          'large',
-          'xlarge',
-          'full',
-          'any CSS size',
-          {
-            size: '...',
-            corner: 'top-left',
-          },
-          {
-            VALUES: {
-              corner: [
-                'top',
-                'left',
-                'bottom',
-                'right',
-                'top-left',
-                'top-right',
-                'bottom-left',
-                'bottom-right',
-              ],
-            },
-          },
-        ],
-        width: [
-          'xxsmall',
-          'xsmall',
-          'small',
-          'medium',
-          'large',
-          'xlarge',
-          'xxlarge',
-          {
-            min: '...',
-            max: '...',
-          },
-          'any CSS size',
-        ],
-      }}
-      themeDoc={themeDoc}
-    />
+    >
+      <Properties>
+        <Property name="a11yTitle">
+          <Description>
+            Custom label to be used by screen readers. When provided, an
+            aria-label will be added to the element.
+          </Description>
+          <GenericA11yTitle />
+        </Property>
+
+        <Property name="alignSelf">
+          <Description>
+            How to align along the cross axis when contained in a Box or along
+            the column axis when contained in a Grid.
+          </Description>
+          <GenericAlignSelf />
+        </Property>
+
+        <Property name="gridArea">
+          <Description>
+            The name of the area to place this inside a parent Grid.
+          </Description>
+          <GenericGridArea />
+        </Property>
+
+        <Property name="margin">
+          <Description>
+            The amount of margin around the component. An object can be
+            specified to distinguish horizontal margin, vertical margin, and
+            margin on a particular side.
+          </Description>
+          <GenericMargin />
+        </Property>
+
+        <Property name="align">
+          <Description>
+            How to align the contents along the cross axis. Any 'align-items'
+            valid CSS value is accepted, including composed ones such 'first
+            baseline' and 'unsafe start'.
+          </Description>
+          <GenericAlign />
+        </Property>
+
+        <Property name="alignContent">
+          <Description>
+            How to align the contents when there is extra space in the cross
+            axis. Any 'align-content' valid CSS value is accepted, including
+            composed ones such 'first baseline' and 'unsafe start'.
+          </Description>
+          <PropertyValue type="string">
+            <Example>"start"</Example>
+            <Example>"center"</Example>
+            <Example>"end"</Example>
+            <Example>"between"</Example>
+            <Example>"around"</Example>
+            <Example defaultValue>"stretch"</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="animation">
+          <Description>
+            Animation effect(s) to use. 'duration' and 'delay' should be in
+            milliseconds. 'jiggle' and 'pulse' types are intended for small
+            elements, like icons.
+          </Description>
+          <PropertyValue type="string">
+            <Example>"fadeIn"</Example>
+            <Example>"fadeOut"</Example>
+            <Example>"jiggle"</Example>
+            <Example>"pulse"</Example>
+            <Example>"rotateLeft"</Example>
+            <Example>"rotateRight"</Example>
+            <Example>"slideUp"</Example>
+            <Example>"slideDown"</Example>
+            <Example>"slideLeft"</Example>
+            <Example>"slideRight"</Example>
+            <Example>"zoomIn"</Example>
+            <Example>"zoomOut"</Example>
+          </PropertyValue>
+          <PropertyValue type="object">
+            <Example>
+              {`
+{
+  type: "...",
+  delay: 0,
+  duration: 1000,
+  size: "xsmall"
+}
+              `}
+            </Example>
+          </PropertyValue>
+          <PropertyValue type="array">
+            <Example>["fadeIn", "slideDown", "..."]</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="background">
+          <Description>
+            The background of the box. Either a color identifier to use for the
+            background color. For example: 'neutral-1'. Or, a 'url()' for an
+            image. Dark is not needed if color is provided.
+          </Description>
+          <PropertyValue type="string">
+            <Description>A color or image url.</Description>
+            <Example>"neutral-1"</Example>
+            <Example>"url(//my.com/assets/img.png)"</Example>
+          </PropertyValue>
+          <PropertyValue type="object">
+            <Example>
+              {`
+{
+  color: "neutral-1",
+  dark: true,
+  opacity: true,
+  position: "bottom",
+  repeat: "no-repeat",
+  size: "cover",
+  image: "url(//my.com/assets/img.png)"
+}
+              `}
+            </Example>
+            <Example>{`{ dark: "light-2", light: "dark-2" }`}</Example>
+            <PropOptions prop="opacity">
+              <Example>"weak"</Example>
+              <Example>"medium"</Example>
+              <Example>"strong"</Example>
+              <Example>true</Example>
+            </PropOptions>
+            <PropOptions prop="position">
+              <Example>any CSS for background-position</Example>
+            </PropOptions>
+            <PropOptions prop="repeat">
+              <Example>"no-repeat"</Example>
+              <Example>"repeat"</Example>
+              <Example>"string"</Example>
+            </PropOptions>
+            <PropOptions prop="size">
+              <Example>"cover"</Example>
+              <Example>"contain"</Example>
+              <Example>"string"</Example>
+            </PropOptions>
+          </PropertyValue>
+        </Property>
+
+        <Property name="basis">
+          <Description>
+            A fixed or relative size along its container's main axis.
+          </Description>
+          <PropertyValue type="string">
+            <Example>"xxsmall"</Example>
+            <SizesXsmallXlarge />
+            <Example>"xxlarge"</Example>
+            <Example>"full"</Example>
+            <Example>"1/2"</Example>
+            <Example>"1/3"</Example>
+            <Example>"2/3"</Example>
+            <Example>"1/4"</Example>
+            <Example>"2/4"</Example>
+            <Example>"3/4"</Example>
+            <Example>"auto"</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="border">
+          <Description>A border around the Box.</Description>
+          <GenericBool />
+          <PropertyValue type="string">
+            <Description>
+              The 'between' option will place a border in the gap between child
+              elements. You must have a 'gap' to use 'between'.
+            </Description>
+            <Example>"top"</Example>
+            <Example>"left"</Example>
+            <Example>"bottom"</Example>
+            <Example>"right"</Example>
+            <Example>"start"</Example>
+            <Example>"end"</Example>
+            <Example>"horizontal"</Example>
+            <Example>"vertical"</Example>
+            <Example>"all"</Example>
+            <Example>"between"</Example>
+          </PropertyValue>
+          <PropertyValue type="object">
+            <Example>
+              {`
+{
+  color: string | { dark: string, light: string },
+  size: "medium",
+  style: "dashed",
+  side: "all"
+}              
+              `}
+            </Example>
+          </PropertyValue>
+          <PropertyValue type="array">
+            <Description>
+              An array of objects defining the border for different sides of the
+              Box.
+            </Description>
+            <Example>
+              {`
+[
+  {
+    color: "black",
+    size: "small",
+    style: "solid",
+    side: "top"
+  },
+  {
+    color: "black",
+    size: "medium",
+    style: "dotted",
+    side: "bottom"
+  }
+]
+              `}
+            </Example>
+            <PropOptions prop="size">
+              <SizesXsmallXlarge />
+              <Example>"any CSS size"</Example>
+            </PropOptions>
+            <PropOptions prop="style">
+              <Example>"solid"</Example>
+              <Example>"dashed"</Example>
+              <Example>"dotted"</Example>
+              <Example>"double"</Example>
+              <Example>"groove"</Example>
+              <Example>"ridge"</Example>
+              <Example>"inset"</Example>
+              <Example>"outset"</Example>
+              <Example>"hidden"</Example>
+            </PropOptions>
+            <PropOptions prop="side">
+              <Example>"top"</Example>
+              <Example>"left"</Example>
+              <Example>"bottom"</Example>
+              <Example>"right"</Example>
+              <Example>"horizontal"</Example>
+              <Example>"vertical"</Example>
+              <Example>"all"</Example>
+            </PropOptions>
+          </PropertyValue>
+        </Property>
+
+        <Property name="direction">
+          <Description>
+            The orientation to layout the child components in.
+          </Description>
+          <PropertyValue type="string">
+            <Example>"row"</Example>
+            <Example defaultValue>"column"</Example>
+            <Example>"row-responsive"</Example>
+            <Example>"row-reverse"</Example>
+            <Example>"column-reverse"</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="elevation">
+          <Description>
+            Elevated height above the underlying context, indicated via a drop
+            shadow.
+          </Description>
+          <GenericElevation />
+        </Property>
+
+        <Property name="flex">
+          <Description>
+            Whether flex-grow and/or flex-shrink is true and at a desired
+            factor.
+          </Description>
+          <PropertyValue type="string">
+            <Example>"grow"</Example>
+            <Example>"shrink"</Example>
+          </PropertyValue>
+          <GenericBool />
+          <PropertyValue type="object">
+            <Example>{`{ grow: number, shrink: number }`}</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="fill">
+          <Description>
+            Whether the width and/or height should fill the container.
+          </Description>
+          <GenericFill />
+        </Property>
+
+        <Property name="focusIndicator">
+          <Description>
+            When interactive via 'onClick', whether it should receive a focus
+            outline.
+          </Description>
+          <GenericBoolTrue />
+        </Property>
+
+        <Property name="gap">
+          <Description>
+            The amount of spacing between child elements. This should not be
+            used in conjunction with 'wrap' as the gap elements will not wrap
+            gracefully. If a child is a Fragment, Box will not add a gap between
+            the children of the Fragment.
+          </Description>
+          <PropertyValue type="string">
+            <Description>
+              T-shirt sizing based off the theme or a specific size in px, em,
+              etc.
+            </Description>
+            <Example>"none"</Example>
+            <SizesXsmallXlarge />
+            <Example>"any CSS size"</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="height">
+          <Description>A fixed height.</Description>
+          <PropertyValue type="string">
+            <Description>
+              T-shirt sizing based off the theme or a specific size in px, em,
+              etc.
+            </Description>
+            <Example>"xxsmall"</Example>
+            <SizesXsmallXlarge />
+            <Example>"xxlarge"</Example>
+            <Example>"any CSS size"</Example>
+          </PropertyValue>
+          <PropertyValue type="object">
+            <Example>{`{ min: "...", max: "..." }`}</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="hoverIndicator">
+          <Description>
+            When 'onClick' has been specified, the hover indicator to apply when
+            the user is mousing over the box.
+          </Description>
+          <GenericBoolFalse />
+          <PropertyValue type="string">
+            <Example>"background"</Example>
+          </PropertyValue>
+          <PropertyValue type="object">
+            <Description>
+              An object defining the background or the background and elevation.
+            </Description>
+            <Example>
+              {`
+{
+  color: "...",
+  dark: "...",
+  image: "string",
+  position: "string",
+  opacity: "...",
+  repeat: "...",
+  size: "...",
+  light: "string"
+}
+              `}
+            </Example>
+            <Example>
+              {`
+{
+  background: {
+    color: "...",
+    dark: "...",
+    image: "string",
+    position: "string",
+    opacity: "...",
+    repeat: "...",
+    size: "...",
+    light: "string"
+  },
+  elevation: "..."
+}
+              `}
+            </Example>
+            <PropOptions prop="color">
+              <Example>"string"</Example>
+              <Example>{`{ dark: "string", light: "string" }`}</Example>
+            </PropOptions>
+            <PropOptions prop="dark">
+              <Example>boolean</Example>
+              <Example>"string"</Example>
+            </PropOptions>
+            <PropOptions prop="opacity">
+              <Example>boolean</Example>
+              <Example>number</Example>
+              <Example>"weak"</Example>
+              <Example>"medium"</Example>
+              <Example>"strong"</Example>
+            </PropOptions>
+            <PropOptions prop="repeat">
+              <Example>"no-repeat"</Example>
+              <Example>"repeat"</Example>
+              <Example>"string"</Example>
+            </PropOptions>
+            <PropOptions prop="size">
+              <Example>"cover"</Example>
+              <Example>"contain"</Example>
+              <Example>"string"</Example>
+            </PropOptions>
+            <PropOptions prop="elevation">
+              <Example>"none"</Example>
+              <SizesXsmallXlarge />
+              <Example>"string"</Example>
+            </PropOptions>
+          </PropertyValue>
+        </Property>
+
+        <Property name="justify">
+          <Description>
+            How to align the contents along the main axis.
+          </Description>
+          <PropertyValue type="string">
+            <Example>"around"</Example>
+            <Example>"between"</Example>
+            <Example>"center"</Example>
+            <Example>"end"</Example>
+            <Example>"evenly"</Example>
+            <Example>"start"</Example>
+            <Example defaultValue>"stretch"</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="onClick">
+          <Description>
+            Click handler. Setting this property adds additional attributes to
+            the DOM for accessibility.
+          </Description>
+          <PropertyValue type="function">
+            <Example>{`() => {}`}</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="overflow">
+          <Description>How to handle Box overflow.</Description>
+          <PropertyValue type="string">
+            <Example>"auto"</Example>
+            <Example>"hidden"</Example>
+            <Example>"scroll"</Example>
+            <Example>"visible"</Example>
+            <Example>"any CSS overflow"</Example>
+          </PropertyValue>
+          <PropertyValue type="object">
+            <Example>{`{ vertical: "...", horizontal: "..." }`}</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="pad">
+          <Description>
+            The amount of padding around the Box contents.
+          </Description>
+          <GenericPad />
+        </Property>
+
+        <Property name="responsive">
+          <Description>
+            Whether margin, pad, and border sizes should be scaled for mobile
+            environments.
+          </Description>
+          <GenericBoolTrue />
+        </Property>
+
+        <Property name="round">
+          <Description>How much to round the corners.</Description>
+          <GenericBool />
+          <PropertyValue type="string">
+            <SizesXsmallXlarge />
+            <Example>"full"</Example>
+            <Example>"any CSS size"</Example>
+          </PropertyValue>
+          <PropertyValue type="object">
+            <Example>{`{ size: "...", corner: "..." }`}</Example>
+            <PropOptions prop="corner">
+              <Example>"top"</Example>
+              <Example>"left"</Example>
+              <Example>"bottom"</Example>
+              <Example>"right"</Example>
+              <Example>"top-left"</Example>
+              <Example>"top-right"</Example>
+              <Example>"bottom-left"</Example>
+              <Example>"bottom-right"</Example>
+            </PropOptions>
+          </PropertyValue>
+        </Property>
+
+        <Property name="tag">
+          <Description>
+            The DOM tag to use for the element. NOTE: This is deprecated in
+            favor of indicating the DOM tag via the 'as' property.
+          </Description>
+          <GenericAs />
+        </Property>
+
+        <Property name="as">
+          <Description>
+            The DOM tag or react component to use for the element.
+          </Description>
+          <GenericAs />
+        </Property>
+
+        <Property name="width">
+          <Description>A fixed width.</Description>
+          <PropertyValue type="string">
+            <Description>
+              T-shirt sizing based off the theme or a specific size in px, em,
+              etc.
+            </Description>
+            <Example>"xxsmall"</Example>
+            <SizesXsmallXlarge />
+            <Example>"xxlarge"</Example>
+            <Example>"any CSS size"</Example>
+          </PropertyValue>
+          <PropertyValue type="object">
+            <Example>{`{ min: "...", max: "..." }`}</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="wrap">
+          <Description>
+            Whether children can wrap if they can't all fit.
+          </Description>
+          <GenericBoolFalse />
+          <PropertyValue type="string">
+            <Example>"reverse"</Example>
+          </PropertyValue>
+        </Property>
+      </Properties>
+
+      <ThemeDoc>
+        <Property name="global.animation">
+          <Description>The animation configuration for the Box.</Description>
+          <GlobalAnimation />
+        </Property>
+
+        <Property name="global.borderSize">
+          <Description>The possible border sizes in the Box.</Description>
+          <GlobalBorderSize />
+        </Property>
+
+        <Property name="global.elevation">
+          <Description>The possible shadows in Box elevation.</Description>
+          <GlobalElevation />
+        </Property>
+
+        <Property name="global.colors.border">
+          <Description>The color of the border.</Description>
+          <GlobalColorsBorder />
+        </Property>
+
+        <Property name="global.hover.background.color">
+          <Description>
+            The color of the default background when hovering.
+          </Description>
+          <GlobalHoverBackgroundColor />
+        </Property>
+
+        <Property name="global.hover.background.opacity">
+          <Description>
+            The opacity of the default background when hovering.
+          </Description>
+          <GlobalHoverBackgroundOpacity />
+        </Property>
+
+        <Property name="global.hover.color">
+          <Description>
+            The color of the default background when hovering.
+          </Description>
+          <GlobalHoverColor />
+        </Property>
+
+        <Property name="global.opacity.medium">
+          <Description>
+            The value used when background opacity is set to true.
+          </Description>
+          <PropertyValue type="number">
+            <Example defaultValue>0.4</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="global.size">
+          <Description>
+            The possible sizes for width, height, and basis.
+          </Description>
+          <PropertyValue type="object">
+            <Example>
+              {`
+{
+  xxsmall: '48px',
+  xsmall: '96px',
+  small: '192px',
+  medium: '384px',
+  large: '768px',
+  xlarge: '1152px',
+  xxlarge: '1536px',
+  full: '100%',
+}
+              `}
+            </Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="box.extend">
+          <Description>Any additional style for the Box.</Description>
+          <GenericExtend />
+        </Property>
+
+        <Property name="box.responsiveBreakpoint">
+          <Description>
+            The actual breakpoint to trigger changes in the border, direction,
+            gap, margin, pad, and round.
+          </Description>
+          <PropertyValue type="string">
+            <Example defaultValue>"small"</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="global.edgeSize">
+          <Description>
+            The possible sizes for any of gap, margin, and pad.
+          </Description>
+          <GlobalEdgeSize />
+        </Property>
+
+        <Property name="global.breakpoints">
+          <Description>
+            The possible breakpoints that could affect border, direction, gap,
+            margin, pad, and round.
+          </Description>
+          <GlobalBreakpoints />
+        </Property>
+      </ThemeDoc>
+    </ComponentDoc>
   </Page>
 );
 

--- a/src/utils/genericPropExamples.js
+++ b/src/utils/genericPropExamples.js
@@ -1,22 +1,90 @@
 import React from 'react';
-import { Markdown } from 'grommet';
 import { Description, Example, PropertyValue } from '../components/Doc';
 
 export const GenericA11yTitle = () => (
-  <Example>"a user friendly label for screen readers"</Example>
+  <PropertyValue type="string">
+    <Example>"a user friendly label for screen readers"</Example>
+  </PropertyValue>
+);
+
+export const GenericAlign = () => (
+  <PropertyValue type="string">
+    <Example>"start"</Example>
+    <Example>"center"</Example>
+    <Example>"end"</Example>
+    <Example>"baseline"</Example>
+    <Example>"stretch</Example>
+  </PropertyValue>
 );
 
 export const GenericAlignSelf = () => (
-  <>
+  <PropertyValue type="string">
     <Example>"start"</Example>
     <Example>"center"</Example>
     <Example>"end"</Example>
     <Example>"stretch"</Example>
+  </PropertyValue>
+);
+
+export const GenericAs = () => (
+  <>
+    <PropertyValue type="string">
+      <Description>The name of a component.</Description>
+      <Example>"div"</Example>
+    </PropertyValue>
+    <PropertyValue type="function">
+      <Example>{`() => {}`}</Example>
+    </PropertyValue>
+  </>
+);
+
+export const GenericBoolTrue = () => (
+  <PropertyValue type="boolean">
+    <Example defaultValue>true</Example>
+    <Example>false</Example>
+  </PropertyValue>
+);
+
+export const GenericBoolFalse = () => (
+  <PropertyValue type="boolean">
+    <Example>true</Example>
+    <Example defaultValue>false</Example>
+  </PropertyValue>
+);
+
+export const GenericBool = () => (
+  <PropertyValue type="boolean">
+    <Example>true</Example>
+    <Example>false</Example>
+  </PropertyValue>
+);
+
+export const GenericElevation = () => (
+  <PropertyValue type="string">
+    <Example defaultValue>"none"</Example>
+    <Example>"xsmall"</Example>
+    <Example>"small"</Example>
+    <Example>"medium"</Example>
+    <Example>"large"</Example>
+    <Example>"xlarge"</Example>
+    <Example>"any custom elevation name in the current theme"</Example>
+  </PropertyValue>
+);
+
+export const GenericFill = () => (
+  <>
+    <PropertyValue type="string">
+      <Example>"horizontal"</Example>
+      <Example>"vertical"</Example>
+    </PropertyValue>
+    <GenericBool />
   </>
 );
 
 export const GenericGridArea = () => (
-  <Example>"a parent grid area name"</Example>
+  <PropertyValue type="string">
+    <Example>"a parent grid area name"</Example>
+  </PropertyValue>
 );
 
 export const GenericMargin = () => (
@@ -36,19 +104,63 @@ export const GenericMargin = () => (
         margin on a particular side.
       </Description>
       <Example>
-        <Markdown>
-          {`
-    {
-        vertical: "...",
-        horizontal: "...",
-        top: "...",
-        bottom: "...",
-        left: "...",
-        right: "..."
-    }
-            `}
-        </Markdown>
+        {`
+{
+    vertical: "...",
+    horizontal: "...",
+    top: "...",
+    bottom: "...",
+    left: "...",
+    right: "..."
+}
+        `}
       </Example>
     </PropertyValue>
+  </>
+);
+
+export const GenericPad = () => (
+  <>
+    <PropertyValue type="string">
+      <Description>
+        T-shirt sizing based off the theme or a specific size in px, em, etc.
+      </Description>
+      <Example defaultValue>"none"</Example>
+      <Example>"xxsmall"</Example>
+      <Example>"xsmall"</Example>
+      <Example>"small"</Example>
+      <Example>"medium"</Example>
+      <Example>"large"</Example>
+      <Example>"xlarge"</Example>
+      <Example>"any CSS size"</Example>
+    </PropertyValue>
+    <PropertyValue type="object">
+      <Description>
+        An object can be specified to distinguish horizontal padding, vertical
+        padding, and padding on a particular side.
+      </Description>
+      <Example>
+        {`
+{
+  vertical: "...",
+  horizontal: "...",
+  top: "...",
+  bottom: "...",
+  left: "...",
+  right: "..."
+}
+        `}
+      </Example>
+    </PropertyValue>
+  </>
+);
+
+export const SizesXsmallXlarge = () => (
+  <>
+    <Example>"xsmall"</Example>
+    <Example>"small"</Example>
+    <Example>"medium"</Example>
+    <Example>"large"</Example>
+    <Example>"xlarge"</Example>
   </>
 );

--- a/src/utils/genericThemeExamples.js
+++ b/src/utils/genericThemeExamples.js
@@ -23,7 +23,191 @@ export const GenericExtend = () => (
       <Example>css`color: 'blue'`</Example>
     </PropertyValue>
     <PropertyValue type="function">
-      <Example>(props) => {}</Example>
+      <Example>{`(props) => {}`}</Example>
     </PropertyValue>
   </>
+);
+
+export const GlobalAnimation = () => (
+  <PropertyValue type="object">
+    <Example>
+      {`
+{
+  duration: '1s',
+  jiggle: { duration: '0.1s' }
+}
+      `}
+    </Example>
+  </PropertyValue>
+);
+
+export const GlobalBorderSize = () => (
+  <PropertyValue type="object">
+    <Example>
+      {`
+{
+  xsmall: '1px',
+  small: '2px',
+  medium: '4px',
+  large: '12px',
+  xlarge: '24px,
+}
+      `}
+    </Example>
+  </PropertyValue>
+);
+
+export const GlobalElevation = () => (
+  <PropertyValue type="object">
+    <Example>
+      {`
+{
+  light: {
+    none: 'none',
+    xsmall: '0px 1px 2px rgba(100, 100, 100, 0.50)',
+    small: '0px 2px 4px rgba(100, 100, 100, 0.50)',
+    medium: '0px 3px 8px rgba(100, 100, 100, 0.50)',
+    large: '0px 6px 12px rgba(100, 100, 100, 0.50)',
+    xlarge: '0px 8px 16px rgba(100, 100, 100, 0.50)',
+  },
+  dark: {
+    none: 'none',
+    xsmall: '0px 2px 2px rgba(255, 255, 255, 0.40)',
+    small: '0px 4px 4px rgba(255, 255, 255, 0.40)',
+    medium: '0px 6px 8px rgba(255, 255, 255, 0.40)',
+    large: '0px 8px 16px rgba(255, 255, 255, 0.40)',
+    xlarge: '0px 10px 24px rgba(255, 255, 255, 0.40)',
+  },
+}
+      `}
+    </Example>
+  </PropertyValue>
+);
+
+export const GlobalColorsBorder = () => (
+  <>
+    <PropertyValue type="string">
+      <Description>A hex, name, or rgb value.</Description>
+      <Example>"brand"</Example>
+    </PropertyValue>
+    <PropertyValue type="object">
+      <Description>
+        An object with a color for dark and light modes.
+      </Description>
+      <Example defaultValue>
+        {`
+{ 
+  dark: rgba(255, 255, 255, 0.33), 
+  light: rgba(0, 0, 0, 0.33), 
+}
+        `}
+      </Example>
+    </PropertyValue>
+  </>
+);
+
+export const GlobalHoverBackgroundColor = () => (
+  <>
+    <PropertyValue type="string">
+      <Description>A hex, name, or rgb value.</Description>
+      <Example defaultValue>"active"</Example>
+    </PropertyValue>
+    <PropertyValue type="object">
+      <Description>
+        An object with a color for dark and light modes.
+      </Description>
+      <Example>{`{ dark: "string", light: "string" }`}</Example>
+    </PropertyValue>
+  </>
+);
+
+export const GlobalHoverBackgroundOpacity = () => (
+  <>
+    <PropertyValue type="string">
+      <Description>A hex, name, or rgb value.</Description>
+      <Example defaultValue>"medium"</Example>
+    </PropertyValue>
+    <PropertyValue type="object">
+      <Description>
+        An object with a color for dark and light modes.
+      </Description>
+      <Example>{`{ dark: "string", light: "string" }`}</Example>
+    </PropertyValue>
+  </>
+);
+
+export const GlobalHoverColor = () => (
+  <>
+    <PropertyValue type="string">
+      <Description>A hex, name, or rgb value.</Description>
+      <Example>"brand"</Example>
+    </PropertyValue>
+    <PropertyValue type="object">
+      <Example defaultValue>{`{ dark: "white", light: "black" }`}</Example>
+    </PropertyValue>
+  </>
+);
+
+export const GlobalEdgeSize = () => (
+  <PropertyValue type="object">
+    <Example>
+      {`
+{
+  edgeSize: {
+    none: '0px',
+    hair: '1px',
+    xxsmall: '3px',
+    xsmall: '6px',
+    small: '12px',
+    medium: '24px',
+    large: '48px',
+    xlarge: '96px',
+    responsiveBreakpoint: 'small',
+  },
+}
+      `}
+    </Example>
+  </PropertyValue>
+);
+
+export const GlobalBreakpoints = () => (
+  <PropertyValue type="object">
+    <Example>
+      {`
+{
+  small: {
+    value: '768px',
+    borderSize: {
+      xsmall: '1px',
+      small: '2px',
+      medium: '4px',
+      large: '6px',
+      xlarge: '12px',
+    },
+    edgeSize: {
+      none: '0px',
+      hair: '1px',
+      xxsmall: '2px',
+      xsmall: '3px',
+      small: '6px',
+      medium: '12px',
+      large: '24px',
+      xlarge: '48px',
+    },
+    size: {
+      xxsmall: '24px',
+      xsmall: '48px',
+      small: '96px',
+      medium: '192px',
+      large: '384px',
+      xlarge: '768px',
+      full: '100%',
+    },
+  },
+  medium: { value: '1536px' },
+  large: {},
+}
+      `}
+    </Example>
+  </PropertyValue>
 );


### PR DESCRIPTION
Box doc uses the new format for documentation

Additional Changes:
`PropExample.js` - added `<pre>` tag so that examples will maintain indentation and line breaks but will also wrap when the screen is resized. This allowed for <Markdown> tags to be removed in `Accordion.js` and `genericPropExamples.js` because they were only being used to maintain indentation in examples.

`PropOptions.js` - added new file to handle example with "where .. could be" (See Box `background`)

`genericPropExamples.js` - made sure each generic example was wrapped in <PropertyValue>, this caused changes in `Accordion.js` and `Anchor.js`