### PR TITLE
Updated CheckBox doc to new format

### DIFF
--- a/src/components/Doc/Description.js
+++ b/src/components/Doc/Description.js
@@ -2,10 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Markdown, Paragraph } from 'grommet';
 
-export const Description = ({ children }) => {
+export const Description = ({ children, disableMarkdown }) => {
   return (
     <Paragraph margin={{ bottom: 'small', top: 'none' }}>
-      <Markdown>{children}</Markdown>
+      {disableMarkdown ? children : <Markdown>{children}</Markdown>}
     </Paragraph>
   );
 };
@@ -13,8 +13,10 @@ Description.displayName = 'Description';
 
 Description.propTypes = {
   children: PropTypes.node,
+  disableMarkdown: PropTypes.bool,
 };
 
 Description.defaultProps = {
   children: undefined,
+  disableMarkdown: false,
 };

--- a/src/screens/CheckBox.js
+++ b/src/screens/CheckBox.js
@@ -1,25 +1,46 @@
 import React from 'react';
-
 import { CheckBox } from 'grommet';
-import { doc, themeDoc } from 'grommet/components/CheckBox/doc';
-
 import Page from '../components/Page';
-import Doc from '../components/Doc';
 import Item from './Components/Item';
-
-const desc = doc(CheckBox).toJSON();
+import {
+  GenericA11yTitle,
+  GenericBool,
+  GenericBoolFalse,
+  SizesXsmallXlarge,
+  GenericPad,
+} from '../utils/genericPropExamples';
+import { GenericColor, GenericExtend } from '../utils/genericThemeExamples';
+import {
+  ComponentDoc,
+  Properties,
+  Property,
+  PropertyValue,
+  Description,
+  Example,
+  ThemeDoc,
+} from '../components/Doc';
 
 export default () => (
   <Page>
-    <Doc
+    <ComponentDoc
       name="CheckBox"
-      desc={desc}
-      syntaxes={{
-        id: 'a-dom-id',
-        label: ['enabled', '<Box>...</Box>'],
-        name: 'a-dom-name',
-        onChange: '() => {}',
-      }}
+      availableAt={[
+        {
+          url:
+            'https://storybook.grommet.io/?selectedKind=Input-CheckBox&full=0&stories=1&panelRight=0',
+          badge:
+            'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
+          label: 'Storybook',
+        },
+        {
+          url:
+            'https://codesandbox.io/s/github/grommet/grommet-sandbox?initialpath=/checkbox&module=%2Fsrc%2FCheckBox.js',
+          badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
+          label: 'CodeSandbox',
+        },
+      ]}
+      description="A checkbox toggle control"
+      intrinsicElement="input"
       code={`function Example() {
   const [checked, setChecked] = React.useState(true);
   return (
@@ -30,8 +51,292 @@ export default () => (
     />
   );
 }`}
-      themeDoc={themeDoc}
-    />
+    >
+      <Properties>
+        <Property name="a11yTitle">
+          <Description>
+            Custom label to be used by screen readers. When provided, an
+            aria-label will be added to the element.
+          </Description>
+          <GenericA11yTitle />
+        </Property>
+
+        <Property name="checked">
+          <Description disableMarkdown>
+            {`Same as React <input checked={} />`}
+          </Description>
+          <GenericBoolFalse />
+        </Property>
+
+        <Property name="disabled">
+          <Description disableMarkdown>
+            {`Same as React <input disabled={} />. Also adds a hidden input
+            element with the same name so form submissions work.`}
+          </Description>
+          <GenericBoolFalse />
+        </Property>
+
+        <Property name="fill">
+          <Description>
+            Whether the checkbox and label expand to fill all of the available
+            width and/or height of their container.
+          </Description>
+          <GenericBool />
+        </Property>
+
+        <Property name="id">
+          <Description disableMarkdown>
+            {`The DOM id attribute value to use for the underlying <input />
+            element.`}
+          </Description>
+          <PropertyValue type="string">
+            <Example>"a-dom-id"</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="label">
+          <Description>
+            Label text to place next to the control. Can be used instead of
+            a11yTitle to meet accessibility requirements
+          </Description>
+          <PropertyValue type="string">
+            <Example>"enabled"</Example>
+          </PropertyValue>
+          <PropertyValue type="element">
+            <Example>{`<Box>...</Box>`}</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="name">
+          <Description disableMarkdown>
+            {`The DOM name attribute value to use for the underlying <input /> element.`}
+          </Description>
+          <PropertyValue type="string">
+            <Example>"a-dom-name"</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="onChange">
+          <Description disableMarkdown>
+            {`Function that will be called when the user clicks the check box. It
+            will be passed a React event object. The current state can be
+            accessed via event.target.checked. Same as React
+            <input onChange={} />.`}
+          </Description>
+          <PropertyValue type="function">
+            <Example>{`() => {}`}</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="pad">
+          <Description>
+            The amount of padding on the container surrounding the checkbox and
+            its label.
+          </Description>
+          <GenericPad />
+        </Property>
+
+        <Property name="reverse">
+          <Description>
+            Whether to show the label in front of the checkbox.
+          </Description>
+          <GenericBoolFalse />
+        </Property>
+
+        <Property name="toggle">
+          <Description>Whether to visualize it as a toggle switch.</Description>
+          <GenericBoolFalse />
+        </Property>
+
+        <Property name="indeterminate">
+          <Description>
+            Whether state is indeterminate. NOTE: This can only be used with
+            non-toggle components
+          </Description>
+          <GenericBoolFalse />
+        </Property>
+      </Properties>
+
+      <ThemeDoc>
+        <Property name="checkBox.border.color">
+          <Description>The border color when unchecked.</Description>
+          <PropertyValue type="string">
+            <Description>A hex, name, or rgb value.</Description>
+            <Example>"black"</Example>
+          </PropertyValue>
+          <PropertyValue type="object">
+            <Description>
+              An object with a color for dark and light modes.
+            </Description>
+            <Example defaultValue>
+              {`{ dark: 'rgba(255, 255, 255, 0.5)', light: 'rgba(0, 0, 0, 0.15)' }`}
+            </Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="checkBox.border.width">
+          <Description>The border width when unchecked.</Description>
+          <PropertyValue type="string">
+            <Example defaultValue>"2px"</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="checkBox.check.extend">
+          <Description>Any additional style for checked CheckBox.</Description>
+          <GenericExtend />
+        </Property>
+
+        <Property name="checkBox.check.radius">
+          <Description>The radius of the checked icon.</Description>
+          <PropertyValue type="string">
+            <Example defaultValue>"4px"</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="checkBox.check.thickness">
+          <Description>The stroke width of the checked icon.</Description>
+          <PropertyValue type="string">
+            <Example defaultValue>"4px"</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="checkBox.color">
+          <Description>
+            The stroke color for the CheckBox icon, and the border when checked.
+          </Description>
+          <GenericColor />
+        </Property>
+
+        <Property name="checkBox.extend">
+          <Description>Any additional style for CheckBox.</Description>
+          <GenericExtend />
+        </Property>
+
+        <Property name="checkBox.gap">
+          <Description>
+            The right margin of the CheckBox to its label.
+          </Description>
+          <PropertyValue type="string">
+            <Description>
+              T-shirt sizing based off the theme or a specific size in px, em,
+              etc.
+            </Description>
+            <Example>"none"</Example>
+            <SizesXsmallXlarge />
+            <Example>"any CSS size"</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="checkBox.hover.border.color">
+          <Description>The border color on hover.</Description>
+          <GenericColor />
+        </Property>
+
+        <Property name="checkBox.hover.background.color">
+          <Description>
+            The background color of the Box surrounding the RadioButton when
+            hovered over.
+          </Description>
+          <GenericColor />
+        </Property>
+
+        <Property name="checkBox.icon.size">
+          <Description>The size of the checked icon.</Description>
+          <PropertyValue type="string">
+            <Example defaultValue>"18px"</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="checkBox.icon.extend">
+          <Description>Any additional style for CheckBox icon.</Description>
+          <GenericExtend />
+        </Property>
+
+        <Property name="checkBox.icons.checked">
+          <Description>The icon to use when checked.</Description>
+          <PropertyValue type="element">
+            <Example defaultValue>{`<FormCheckmark />`}</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="checkBox.icons.indeterminate">
+          <Description>The icon to use when indeterminate.</Description>
+          <PropertyValue type="element">
+            <Example>{`<FormCheckmark />`}</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="checkBox.label.align">
+          <Description>How to align the checkbox and label.</Description>
+          <PropertyValue type="string">
+            <Example defaultValue>"center"</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="checkBox.pad">
+          <Description>The pad around the CheckBox and its label.</Description>
+          <GenericPad />
+        </Property>
+
+        <Property name="checkBox.size">
+          <Description>
+            The height and width used for the CheckBox icon.
+          </Description>
+          <PropertyValue type="string">
+            <Example defaultValue>"24px"</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="checkBox.toggle.background">
+          <Description>The background color of the toggle.</Description>
+          <GenericColor />
+        </Property>
+
+        <Property name="checkBox.toggle.color">
+          <Description>The color of the toggle knob.</Description>
+          <PropertyValue type="string">
+            <Description>A hex, name, or rgb value.</Description>
+            <Example>"#d9d9d9"</Example>
+          </PropertyValue>
+          <PropertyValue type="object">
+            <Description>
+              An object with a color for dark and light modes.
+            </Description>
+            <Example defaultValue>
+              {`{ dark: "#d9d9d9", light: "#d9d9d9" }`}
+            </Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="checkBox.toggle.extend">
+          <Description>Any additional style for CheckBox toggle.</Description>
+          <GenericExtend />
+        </Property>
+
+        <Property name="checkBox.toggle.knob.extend">
+          <Description>
+            Any additional style for the CheckBox toggle knob.
+          </Description>
+          <GenericExtend />
+        </Property>
+
+        <Property name="checkBox.toggle.radius">
+          <Description>
+            The border radius used for the toggle and the knob.
+          </Description>
+          <PropertyValue type="string">
+            <Example defaultValue>"24px"</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="checkBox.toggle.size">
+          <Description>The width size of the toggle.</Description>
+          <PropertyValue type="string">
+            <Example defaultValue>"48px"</Example>
+          </PropertyValue>
+        </Property>
+      </ThemeDoc>
+    </ComponentDoc>
   </Page>
 );
 

--- a/src/utils/genericPropExamples.js
+++ b/src/utils/genericPropExamples.js
@@ -142,12 +142,14 @@ export const GenericPad = () => (
       <Example>
         {`
 {
-  vertical: "...",
-  horizontal: "...",
-  top: "...",
   bottom: "...",
+  end: "...",
+  horizontal: "...",
   left: "...",
-  right: "..."
+  right: "...",
+  start: "...",
+  top: "...",
+  vertical: "..."
 }
         `}
       </Example>

--- a/src/utils/genericPropExamples.js
+++ b/src/utils/genericPropExamples.js
@@ -142,14 +142,14 @@ export const GenericPad = () => (
       <Example>
         {`
 {
-  bottom: "...",
-  end: "...",
+  vertical: "...",
   horizontal: "...",
+  top: "...",
+  bottom: "...",
   left: "...",
   right: "...",
   start: "...",
-  top: "...",
-  vertical: "..."
+  end: "..."
 }
         `}
       </Example>


### PR DESCRIPTION
CheckBox doc uses new format
Issue #233 

Description.js - added ability to disable styling markdown for examples that need it. See checked prop in CheckBox.js

genericPropExamples.js - GenericPad previously left out 'end' and 'start' options