### PR TITLE
Final polish of docs

### DIFF
--- a/src/components/Doc/DomProps.js
+++ b/src/components/Doc/DomProps.js
@@ -6,7 +6,6 @@ import { Link as LinkIcon } from 'grommet-icons';
 export const DomProps = ({ name, intrinsicElement }) => {
   const Elements = [];
   if (typeof intrinsicElement === 'object') {
-    console.log(intrinsicElement.length);
     for (let i = 0; i < intrinsicElement.length; i += 1) {
       Elements.push(
         <IntrinsicDoc name={name} key={i} element={intrinsicElement[i]} />,

--- a/src/screens/Accordion.js
+++ b/src/screens/Accordion.js
@@ -38,7 +38,7 @@ export default () => (
           label: 'CodeSandbox',
         },
       ]}
-      description="An accordion containing collapsible panels."
+      description="An accordion containing collapsible panels"
       intrinsicElement="div"
       code={`<Accordion>
   <AccordionPanel label="Panel 1">

--- a/src/screens/Calendar.js
+++ b/src/screens/Calendar.js
@@ -41,9 +41,7 @@ export default () => (
           label: 'CodeSandbox',
         },
       ]}
-      description="A calendar of days displayed by month.
- It can be used to select a single date, a range of dates, or multiple
- individual dates."
+      description="A calendar of days displayed by month"
       intrinsicElement="div"
       code={`<Calendar
   size="small"
@@ -76,11 +74,7 @@ export default () => (
         </Property>
 
         <Property name="margin">
-          <Description>
-            The amount of margin around the component. An object can be
-            specified to distinguish horizontal margin, vertical margin, and
-            margin on a particular side.
-          </Description>
+          <Description>The amount of margin around the component.</Description>
           <GenericMargin />
         </Property>
 

--- a/src/screens/Card.js
+++ b/src/screens/Card.js
@@ -113,6 +113,7 @@ export default () => (
         base: 'Footer',
         path: '/footer',
       }}
+      pageTitle="Card"
     />
   </Page>
 );

--- a/src/screens/Carousel.js
+++ b/src/screens/Carousel.js
@@ -79,11 +79,7 @@ export default () => (
         </Property>
 
         <Property name="margin">
-          <Description>
-            The amount of margin around the component. An object can be
-            specified to distinguish horizontal margin, vertical margin, and
-            margin on a particular side.
-          </Description>
+          <Description>The amount of margin around the component.</Description>
           <GenericMargin />
         </Property>
 

--- a/src/screens/Chart.js
+++ b/src/screens/Chart.js
@@ -83,11 +83,7 @@ export default () => (
         </Property>
 
         <Property name="margin">
-          <Description>
-            The amount of margin around the component. An object can be
-            specified to distinguish horizontal margin, vertical margin, and
-            margin on a particular side.
-          </Description>
+          <Description>The amount of margin around the component.</Description>
           <GenericMargin />
         </Property>
 
@@ -512,6 +508,7 @@ export default () => (
     <ComponentDoc
       name="calcs()"
       description="a function to help calculate values for bounds and axis"
+      pageTitle="Chart"
     >
       <code>
         {`const { axis, bounds, pad, thickness } = calcs(values, { coarseness, steps })`}

--- a/src/screens/CheckBoxGroup.js
+++ b/src/screens/CheckBoxGroup.js
@@ -115,11 +115,11 @@ export default () => (
               property, use CheckBoxGroup 'value' prop instead of 'checked'.
             </Description>
             <Example>
-              {`{[
+              {`[
   { label: 'Maui' },
   { label: 'Jerusalem' },
   { label: 'Wuhan' },
-]}`}
+]`}
             </Example>
           </PropertyValue>
         </Property>

--- a/src/screens/Clock.js
+++ b/src/screens/Clock.js
@@ -68,11 +68,7 @@ export default () => (
         </Property>
 
         <Property name="margin">
-          <Description>
-            The amount of margin around the component. An object can be
-            specified to distinguish horizontal margin, vertical margin, and
-            margin on a particular side.
-          </Description>
+          <Description>The amount of margin around the component.</Description>
           <GenericMargin />
         </Property>
 

--- a/src/screens/DataChart.js
+++ b/src/screens/DataChart.js
@@ -165,11 +165,7 @@ export default () => (
         </Property>
 
         <Property name="margin">
-          <Description>
-            The amount of margin around the component. An object can be
-            specified to distinguish horizontal margin, vertical margin, and
-            margin on a particular side.
-          </Description>
+          <Description>The amount of margin around the component.</Description>
           <GenericMargin />
         </Property>
 

--- a/src/screens/DataTable.js
+++ b/src/screens/DataTable.js
@@ -97,11 +97,7 @@ export default () => (
         </Property>
 
         <Property name="margin">
-          <Description>
-            The amount of margin around the component. An object can be
-            specified to distinguish horizontal margin, vertical margin, and
-            margin on a particular side.
-          </Description>
+          <Description>The amount of margin around the component.</Description>
           <GenericMargin />
         </Property>
 
@@ -152,9 +148,9 @@ export default () => (
             <Example>
               {`
 {
-  "color": "border",
-  "side": "horizontal",
-  "size": "small"
+  color: "border",
+  side: "horizontal",
+  size: "small"
 }
             `}
             </Example>

--- a/src/screens/Distribution.js
+++ b/src/screens/Distribution.js
@@ -81,11 +81,7 @@ export default () => (
         </Property>
 
         <Property name="margin">
-          <Description>
-            The amount of margin around the component. An object can be
-            specified to distinguish horizontal margin, vertical margin, and
-            margin on a particular side.
-          </Description>
+          <Description>The amount of margin around the component.</Description>
           <GenericMargin />
         </Property>
 

--- a/src/screens/Drop.js
+++ b/src/screens/Drop.js
@@ -125,11 +125,7 @@ export default () => (
         </Property>
 
         <Property name="margin">
-          <Description>
-            The amount of margin around the component. An object can be
-            specified to distinguish horizontal margin, vertical margin, and
-            margin on a particular side.
-          </Description>
+          <Description>The amount of margin around the component.</Description>
           <GenericMargin />
         </Property>
 

--- a/src/screens/FormField.js
+++ b/src/screens/FormField.js
@@ -160,11 +160,7 @@ export default () => (
         </Property>
 
         <Property name="margin">
-          <Description>
-            The amount of margin around the component. An object can be
-            specified to distinguish horizontal margin, vertical margin, and
-            margin on a particular side.
-          </Description>
+          <Description>The amount of margin around the component.</Description>
           <GenericMargin />
         </Property>
 

--- a/src/screens/Grid.js
+++ b/src/screens/Grid.js
@@ -91,11 +91,7 @@ export default () => (
         </Property>
 
         <Property name="margin">
-          <Description>
-            The amount of margin around the component. An object can be
-            specified to distinguish horizontal margin, vertical margin, and
-            margin on a particular side.
-          </Description>
+          <Description>The amount of margin around the component.</Description>
           <GenericMargin />
         </Property>
 

--- a/src/screens/Markdown.js
+++ b/src/screens/Markdown.js
@@ -33,7 +33,7 @@ export default () => (
           label: 'CodeSandbox',
         },
       ]}
-      description="Markdown formatting using Grommet components."
+      description="Markdown formatting using Grommet components"
       intrinsicElement="div"
       code={`<Markdown>${CONTENT}</Markdown>`}
     >

--- a/src/screens/Paragraph.js
+++ b/src/screens/Paragraph.js
@@ -45,7 +45,7 @@ export default () => (
           label: 'CodeSandbox',
         },
       ]}
-      description="A paragraph of text."
+      description="A paragraph of text"
       intrinsicElement="p"
       code={`<Paragraph margin="none">
   Lorem ipsum dolor sit amet,


### PR DESCRIPTION
- Removes a console.log statement
- Removes period from initial component description at top of the page (periods should follow all other descriptions within the props and theme sections) 
- Fixes any typos 
- Removes duplicate descriptions (ex. "An object can be specified to distinguish horizontal margin, vertical margin, and margin on a particular side." is already stated in the object description of <GenericMargin />)