### PR TITLE
add semicircle to meter type

### DIFF
--- a/src/screens/Meter.js
+++ b/src/screens/Meter.js
@@ -155,6 +155,7 @@ export default () => (
             <Example defaultValue>"bar"</Example>
             <Example>"circle"</Example>
             <Example>"pie"</Example>
+            <Example>"semicircle"</Example>
           </PropertyValue>
         </Property>
 


### PR DESCRIPTION
Add in  `semicirlce` to Meter type 

This was an enhancement added to grommet 
https://github.com/grommet/grommet/pull/5463