### PR TITLE
Fix prop anchor links to scroll to location

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -16,11 +16,6 @@ export const Router = ({ children, initialPath }) => {
       const { location } = document;
       setPath(location.pathname);
       setSearch(location.search);
-      // Any time the route updates the user will be scrolled to
-      // the hash. This is loose and may be problematic.
-      if (typeof window !== 'undefined' && location.hash) {
-        window.scrollTo(document.getElementById(location.hash));
-      }
     };
     window.addEventListener('popstate', onPopState);
     onPopState();

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -1,16 +1,37 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { Box } from 'grommet';
 import Nav from './Nav';
 
-const Page = ({ children, background }) => (
-  <Box pad="large" background={background}>
-    <Box>
-      <Nav />
-      <Box margin={{ top: 'large' }}>{children}</Box>
-    </Box>
-  </Box>
-);
+export default class Page extends Component {
+  componentDidMount() {
+    this.scrollToSection();
+  }
+
+  componentDidUpdate() {
+    this.scrollToSection();
+  }
+
+  scrollToSection = () => {
+    const name = window.location.hash.split('#')[1];
+    if (name) {
+      document.getElementById(name).scrollIntoView({
+        behavior: 'smooth',
+        block: 'start',
+      });
+    }
+  };
+
+  render() {
+    const { background, children } = this.props;
+    return (
+      <Box pad="large" background={background}>
+        <Box>
+          <Nav />
+          <Box margin={{ top: 'large' }}>{children}</Box>
+        </Box>
+      </Box>
+    );
+  }
+}
 
 Page.propTypes = Box.propTypes;
-
-export default Page;

--- a/src/screens/Components/index.js
+++ b/src/screens/Components/index.js
@@ -144,24 +144,6 @@ export default class Components extends Component {
     });
   }
 
-  componentDidMount() {
-    this.scrollToSection();
-  }
-
-  componentDidUpdate() {
-    this.scrollToSection();
-  }
-
-  scrollToSection = () => {
-    const name = window.location.hash.split('#')[1];
-    if (name && this.sectionRefs[name]) {
-      this.sectionRefs[name].current.scrollIntoView({
-        behavior: 'smooth',
-        block: 'start',
-      });
-    }
-  };
-
   render() {
     const desc =
       'These are the building blocks of the grommet library, master them, and become a l33t.';


### PR DESCRIPTION
Fixes doc links that reference a specific prop on a component page to scroll down to that section when you navigate to the link.
Closes #294 