### PR TITLE
Fix List onClickItem example

### DIFF
--- a/src/screens/List.js
+++ b/src/screens/List.js
@@ -197,15 +197,15 @@ export default () => (
         <Property name="onClickItem">
           <Description>
             When supplied, this function will be called with an event object
-            that include a 'item' property containing the data value associated
-            with the clicked item and an 'index' property containing the index
-            in 'data' of the clicked item. You should not include interactive
-            elements, like Anchor or Button inside 'primaryKey' or
+            which includes an 'item' property containing the data value
+            associated with the clicked item and an 'index' property containing
+            the index in 'data' of the clicked item. You should not include
+            interactive elements, like Anchor or Button inside 'primaryKey' or
             'secondaryKey' as that can cause confusion with overlapping
             interactive elements.
           </Description>
           <PropertyValue type="function">
-            <Example>{`({ datum, index }) => {}`}</Example>
+            <Example>{`({ item, index }) => {}`}</Example>
           </PropertyValue>
         </Property>
 


### PR DESCRIPTION
Closes https://github.com/grommet/grommet-site/issues/308

Updates List's `onClickItem` prop example to show the event object's `item` property instead of `datum` which is not a property on the event object.

**Before**:
![Screen Shot 2021-09-08 at 1 51 51 PM](https://user-images.githubusercontent.com/1756948/132576407-cf98fd0e-c23b-4a85-8179-8cef04185aa1.png)


**After**:
![Screen Shot 2021-09-08 at 1 52 04 PM](https://user-images.githubusercontent.com/1756948/132576397-b3f16425-2502-4c57-9af5-ffa9798e7560.png)
