### PR TITLE
Feature: Links to Github for Components

### DIFF
--- a/src/components/Doc/ComponentDoc.js
+++ b/src/components/Doc/ComponentDoc.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Helmet from 'react-helmet';
 import PropTypes from 'prop-types';
 import { Anchor, Box, Paragraph, Text } from 'grommet';
+import { Github } from 'grommet-icons';
 import Header from '../Header';
 import RoutedAnchor from '../RoutedAnchor';
 import { Code } from './Code';
@@ -60,6 +61,7 @@ export const ComponentDoc = ({
                   <Anchor
                     key={at.url}
                     href={at.url}
+                    icon={at.label === 'Github' ? <Github /> : null}
                     target="_blank"
                     label={<Text size="large">{at.label}</Text>}
                   />

--- a/src/screens/Accordion.js
+++ b/src/screens/Accordion.js
@@ -37,6 +37,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Accordion',
+          label: 'Github',
+        },
       ]}
       description="An accordion containing collapsible panels"
       intrinsicElement="div"

--- a/src/screens/Anchor.js
+++ b/src/screens/Anchor.js
@@ -38,6 +38,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Anchor',
+          label: 'Github',
+        },
       ]}
       description="A text link"
       details="We have a separate component from the browser\nbase so we can style it. You can either set the icon and/or label properties\nor just use children."

--- a/src/screens/Avatar.js
+++ b/src/screens/Avatar.js
@@ -25,6 +25,11 @@ export default () => (
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Avatar',
+          label: 'Github',
+        },
       ]}
       description="An Avatar"
       intrinsicElement="div"

--- a/src/screens/Box.js
+++ b/src/screens/Box.js
@@ -59,6 +59,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Box',
+          label: 'Github',
+        },
       ]}
       description="A container that lays out its contents in one direction"
       intrinsicElement="div"

--- a/src/screens/Button.js
+++ b/src/screens/Button.js
@@ -53,6 +53,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Button',
+          label: 'Github',
+        },
       ]}
       intrinsicElement="button"
       code={`<Button primary label="label" />`}

--- a/src/screens/Calendar.js
+++ b/src/screens/Calendar.js
@@ -40,6 +40,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Calendar',
+          label: 'Github',
+        },
       ]}
       description="A calendar of days displayed by month"
       intrinsicElement="div"

--- a/src/screens/Card.js
+++ b/src/screens/Card.js
@@ -25,6 +25,11 @@ export default () => (
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Card',
+          label: 'Github',
+        },
       ]}
       description="A Card is a container of information that provides access to more 
  details"

--- a/src/screens/Carousel.js
+++ b/src/screens/Carousel.js
@@ -43,6 +43,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Carousel',
+          label: 'Github',
+        },
       ]}
       description="A carousel that cycles through children"
       intrinsicElement="div"

--- a/src/screens/Chart.js
+++ b/src/screens/Chart.js
@@ -41,6 +41,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Chart',
+          label: 'Github',
+        },
       ]}
       description="A graphical chart"
       code={`<Chart

--- a/src/screens/CheckBox.js
+++ b/src/screens/CheckBox.js
@@ -38,6 +38,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/CheckBox',
+          label: 'Github',
+        },
       ]}
       description="A checkbox toggle control"
       intrinsicElement="input"

--- a/src/screens/CheckBoxGroup.js
+++ b/src/screens/CheckBoxGroup.js
@@ -24,6 +24,11 @@ export default () => (
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/CheckBoxGroup',
+          label: 'Github',
+        },
       ]}
       description="A group of CheckBoxes"
       intrinsicElement="div"

--- a/src/screens/Clock.js
+++ b/src/screens/Clock.js
@@ -38,6 +38,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Clock',
+          label: 'Github',
+        },
       ]}
       description="A clock with timezone awareness"
       intrinsicElement={['div', 'svg']}

--- a/src/screens/Collapsible.js
+++ b/src/screens/Collapsible.js
@@ -27,6 +27,11 @@ export default () => (
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Collapsible',
+          label: 'Github',
+        },
       ]}
       code={`() => {
 const [open, setOpen] = React.useState(false);

--- a/src/screens/DataChart.js
+++ b/src/screens/DataChart.js
@@ -137,6 +137,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/DataChart',
+          label: 'Github',
+        },
       ]}
     >
       <Examples />

--- a/src/screens/DataTable.js
+++ b/src/screens/DataTable.js
@@ -40,6 +40,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/DataTable',
+          label: 'Github',
+        },
       ]}
       description="A data driven table"
       intrinsicElement="table"

--- a/src/screens/DateInput.js
+++ b/src/screens/DateInput.js
@@ -34,6 +34,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/DateInput',
+          label: 'Github',
+        },
       ]}
       description="A control to input a single date or a date range"
       intrinsicElement="div"

--- a/src/screens/Diagram.js
+++ b/src/screens/Diagram.js
@@ -44,6 +44,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Diagram',
+          label: 'Github',
+        },
       ]}
       description="Graphical connection lines"
       intrinsicElement="svg"

--- a/src/screens/Distribution.js
+++ b/src/screens/Distribution.js
@@ -37,6 +37,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Distribution',
+          label: 'Github',
+        },
       ]}
       description="Proportionally sized grid of boxes"
       intrinsicElement="div"

--- a/src/screens/Drop.js
+++ b/src/screens/Drop.js
@@ -35,6 +35,11 @@ export default () => (
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Drop',
+          label: 'Github',
+        },
       ]}
       description="A container that is overlaid next to a target"
       intrinsicElement="div"

--- a/src/screens/DropButton.js
+++ b/src/screens/DropButton.js
@@ -37,6 +37,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/DropButton',
+          label: 'Github',
+        },
       ]}
       description="A Button that controls a Drop"
       intrinsicElement="button"

--- a/src/screens/FileInput.js
+++ b/src/screens/FileInput.js
@@ -33,6 +33,11 @@ export default () => (
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/FileInput',
+          label: 'Github',
+        },
       ]}
       description="A control to input one or more files"
       intrinsicElement="input"

--- a/src/screens/Footer.js
+++ b/src/screens/Footer.js
@@ -16,6 +16,11 @@ export default () => (
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Footer',
+          label: 'Github',
+        },
       ]}
       description="Footer for a document or section"
       code={`<Footer background="brand" pad="medium">

--- a/src/screens/Form.js
+++ b/src/screens/Form.js
@@ -108,6 +108,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Form',
+          label: 'Github',
+        },
       ]}
     >
       <Examples />

--- a/src/screens/FormField.js
+++ b/src/screens/FormField.js
@@ -39,6 +39,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/FormField',
+          label: 'Github',
+        },
       ]}
       description="A single field in a form"
       intrinsicElement="div"

--- a/src/screens/Grid.js
+++ b/src/screens/Grid.js
@@ -61,6 +61,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Grid',
+          label: 'Github',
+        },
       ]}
       description="A grid system for laying out content"
       intrinsicElement="div"

--- a/src/screens/Grommet.js
+++ b/src/screens/Grommet.js
@@ -33,6 +33,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Grommet',
+          label: 'Github',
+        },
       ]}
       description="The top level Grommet container"
       intrinsicElement="div"

--- a/src/screens/Header.js
+++ b/src/screens/Header.js
@@ -16,6 +16,11 @@ export default () => (
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Header',
+          label: 'Github',
+        },
       ]}
       description="Is a Box container for introductory content"
       code={`<Header background="brand">

--- a/src/screens/Heading.js
+++ b/src/screens/Heading.js
@@ -41,6 +41,11 @@ export default () => (
           url:
             'https://codesandbox.io/s/github/grommet/grommet-sandbox?initialpath=/heading&module=%2Fsrc%2FHeading.js',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Heading',
+          label: 'Github',
+        },
       ]}
       description="Heading text structured in levels"
       intrinsicElement={['h1', 'h2', 'h3', 'h4']}

--- a/src/screens/Image.js
+++ b/src/screens/Image.js
@@ -39,6 +39,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Image',
+          label: 'Github',
+        },
       ]}
       description="An image"
       intrinsicElement="img"

--- a/src/screens/InfiniteScroll.js
+++ b/src/screens/InfiniteScroll.js
@@ -30,6 +30,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/InfiniteScroll',
+          label: 'Github',
+        },
       ]}
       description="A container that lazily renders items"
       code={`<Box height="small" overflow="auto">

--- a/src/screens/Keyboard.js
+++ b/src/screens/Keyboard.js
@@ -18,6 +18,13 @@ export default () => (
     <ComponentDoc
       name="Keyboard"
       description="A handler of keyboard key presses"
+      availableAt={[
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Keyboard',
+          label: 'Github',
+        },
+      ]}
       code={`<Keyboard onEsc={() => {}}>
   <Box pad="large" background="light-4" />
 </Keyboard>`}

--- a/src/screens/Layer.js
+++ b/src/screens/Layer.js
@@ -40,6 +40,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Layer',
+          label: 'Github',
+        },
       ]}
       description="An overlay"
       intrinsicElement="div"

--- a/src/screens/List.js
+++ b/src/screens/List.js
@@ -33,6 +33,11 @@ export default () => (
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/List',
+          label: 'Github',
+        },
       ]}
       description="An ordered list of items"
       intrinsicElement="ol"

--- a/src/screens/Main.js
+++ b/src/screens/Main.js
@@ -16,6 +16,11 @@ export default () => (
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Main',
+          label: 'Github',
+        },
       ]}
       description="main content of a document"
       isA={{

--- a/src/screens/Markdown.js
+++ b/src/screens/Markdown.js
@@ -32,6 +32,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Markdown',
+          label: 'Github',
+        },
       ]}
       description="Markdown formatting using Grommet components"
       intrinsicElement="div"

--- a/src/screens/MaskedInput.js
+++ b/src/screens/MaskedInput.js
@@ -46,6 +46,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/MaskedInput',
+          label: 'Github',
+        },
       ]}
       description="An input field with formalized syntax"
       intrinsicElement="input"

--- a/src/screens/Menu.js
+++ b/src/screens/Menu.js
@@ -40,6 +40,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Menu',
+          label: 'Github',
+        },
       ]}
       description="A control that opens a Drop containing plain Buttons"
       intrinsicElement="button"

--- a/src/screens/Meter.js
+++ b/src/screens/Meter.js
@@ -44,6 +44,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Meter',
+          label: 'Github',
+        },
       ]}
       description="A graphical meter"
       code={`<Meter

--- a/src/screens/Nav.js
+++ b/src/screens/Nav.js
@@ -17,6 +17,11 @@ export default () => (
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Nav',
+          label: 'Github',
+        },
       ]}
       description="Is a Box container for navigation links"
       isA={{

--- a/src/screens/Notification.js
+++ b/src/screens/Notification.js
@@ -32,6 +32,11 @@ export default () => (
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Notification',
+          label: 'Github',
+        },
       ]}
       code={`<Notification
   title="Default Status Title"

--- a/src/screens/Pagination.js
+++ b/src/screens/Pagination.js
@@ -31,6 +31,11 @@ export default () => (
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Pagination',
+          label: 'Github',
+        },
       ]}
       description="A control that enables selection of a single page from a 
  range of pages"

--- a/src/screens/Paragraph.js
+++ b/src/screens/Paragraph.js
@@ -44,6 +44,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Paragraph',
+          label: 'Github',
+        },
       ]}
       description="A paragraph of text"
       intrinsicElement="p"

--- a/src/screens/RadioButton.js
+++ b/src/screens/RadioButton.js
@@ -32,6 +32,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/RadioButton',
+          label: 'Github',
+        },
       ]}
       description="A radio button control"
       intrinsicElement="input"

--- a/src/screens/RadioButtonGroup.js
+++ b/src/screens/RadioButtonGroup.js
@@ -25,6 +25,11 @@ export default () => (
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/RadioButtonGroup',
+          label: 'Github',
+        },
       ]}
       description="A group of radio buttons"
       intrinsicElement="div"

--- a/src/screens/RangeInput.js
+++ b/src/screens/RangeInput.js
@@ -37,6 +37,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/RangeInput',
+          label: 'Github',
+        },
       ]}
       description="A slider control to input a value within a fixed range"
       intrinsicElement="input"

--- a/src/screens/RangeSelector.js
+++ b/src/screens/RangeSelector.js
@@ -32,6 +32,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/RangeSelector',
+          label: 'Github',
+        },
       ]}
       description="A control to input a range of values"
       intrinsicElement="div"

--- a/src/screens/Select.js
+++ b/src/screens/Select.js
@@ -41,6 +41,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Select',
+          label: 'Github',
+        },
       ]}
       description="A control to select a value, with optional search"
       code={`function Example() {

--- a/src/screens/Sidebar.js
+++ b/src/screens/Sidebar.js
@@ -23,6 +23,11 @@ export default () => (
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Sidebar',
+          label: 'Github',
+        },
       ]}
       description="A sidebar, typically used with Nav children"
       intrinsicElement="div"

--- a/src/screens/SkipLinks.js
+++ b/src/screens/SkipLinks.js
@@ -37,6 +37,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/SkipLinks',
+          label: 'Github',
+        },
       ]}
       description="Describe a list of elements to skip to"
     >

--- a/src/screens/Spinner.js
+++ b/src/screens/Spinner.js
@@ -31,6 +31,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Spinner',
+          label: 'Github',
+        },
       ]}
       description="A Spinner"
       code="<Spinner />"

--- a/src/screens/Stack.js
+++ b/src/screens/Stack.js
@@ -38,6 +38,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Stack',
+          label: 'Github',
+        },
       ]}
       description="A container that stacks contents on top of each other"
       intrinsicElement="div"

--- a/src/screens/Table.js
+++ b/src/screens/Table.js
@@ -41,6 +41,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Table',
+          label: 'Github',
+        },
       ]}
       description="A table of data organized in cells"
       intrinsicElement="table"

--- a/src/screens/Tabs.js
+++ b/src/screens/Tabs.js
@@ -40,6 +40,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Tabs',
+          label: 'Github',
+        },
       ]}
       description="A container with controls to show one Tab at a time"
       intrinsicElement="div"

--- a/src/screens/Text.js
+++ b/src/screens/Text.js
@@ -39,6 +39,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Text',
+          label: 'Github',
+        },
       ]}
       description="Arbitrary text"
       intrinsicElement="span"

--- a/src/screens/TextArea.js
+++ b/src/screens/TextArea.js
@@ -44,6 +44,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/TextArea',
+          label: 'Github',
+        },
       ]}
       description="A control to input multiple lines of text"
       intrinsicElement="textarea"

--- a/src/screens/TextInput.js
+++ b/src/screens/TextInput.js
@@ -42,6 +42,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/TextInput',
+          label: 'Github',
+        },
       ]}
       description="A control to input a single line of text, with optional suggestions"
       intrinsicElement="input"

--- a/src/screens/Tip.js
+++ b/src/screens/Tip.js
@@ -25,6 +25,11 @@ export default () => (
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Tip',
+          label: 'Github',
+        },
       ]}
       description="Tooltip or a hint when hovering over an element"
       code={`<Grommet theme={grommet}>

--- a/src/screens/Video.js
+++ b/src/screens/Video.js
@@ -39,6 +39,11 @@ export default () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/Video',
+          label: 'Github',
+        },
       ]}
       description="A video player"
       intrinsicElement="video"

--- a/src/screens/WorldMap.js
+++ b/src/screens/WorldMap.js
@@ -39,6 +39,11 @@ const WorldMapDoc = () => (
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
+        {
+          url:
+            'https://github.com/grommet/grommet/tree/master/src/js/components/WorldMap',
+          label: 'Github',
+        },
       ]}
       description="A map of the world, or a continent"
       intrinsicElement="svg"


### PR DESCRIPTION
This PR aims to:
- Resolve #219
- Introduces a direct link to a component's folder in the grommet repo
