### PR TITLE
Feature: adding maxSize prop to FileInput docs

### DIFF
--- a/src/screens/FileInput.js
+++ b/src/screens/FileInput.js
@@ -59,6 +59,15 @@ export default () => (
           </PropertyValue>
         </Property>
 
+        <Property name="maxSize">
+          <Description>
+            Specifies a file size limit in bytes for FileInput.
+          </Description>
+          <PropertyValue type="number">
+            <Example>5000</Example>
+          </PropertyValue>
+        </Property>
+
         <Property name="messages">
           <Description>
             Custom messages for FileInput. Used for accessibility by screen


### PR DESCRIPTION
This PR aims to:
- Adds `maxSize` prop to FileInput docs in relation to grommet/grommet#5320 