### PR TITLE
Tabs alignControl prop: editing description

### DIFF
--- a/src/screens/Tabs.js
+++ b/src/screens/Tabs.js
@@ -28,21 +28,18 @@ export default () => (
       name="Tabs"
       availableAt={[
         {
-          url:
-            'https://storybook.grommet.io/?selectedKind=Controls-Tabs&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?selectedKind=Controls-Tabs&full=0&stories=1&panelRight=0',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',
         },
         {
-          url:
-            'https://codesandbox.io/s/github/grommet/grommet-sandbox?initialpath=/tabs&module=%2Fsrc%2FTabs.js',
+          url: 'https://codesandbox.io/s/github/grommet/grommet-sandbox?initialpath=/tabs&module=%2Fsrc%2FTabs.js',
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
         {
-          url:
-            'https://github.com/grommet/grommet/tree/master/src/js/components/Tabs',
+          url: 'https://github.com/grommet/grommet/tree/master/src/js/components/Tabs',
           label: 'Github',
         },
       ]}
@@ -99,7 +96,7 @@ export default () => (
 
         <Property name="alignControls">
           <Description>
-            How to align the tab controls within the tabs header.
+            How to align the tab controls along the vertical axis.
           </Description>
           <PropertyValue type="string">
             <Example>"start"</Example>


### PR DESCRIPTION
This PR Aims to resolve:
- A slight revision needed for Tabs' `alignControls` prop  in an issue found [here](https://github.com/grommet/grommet/issues/5448)
- Updates to the documentation to explain `alignControls` is in reference to how the tab controls align on the vertical axis