### PR TITLE
Feature: Anchor As Prop Extension

### DIFF
--- a/src/screens/Anchor.js
+++ b/src/screens/Anchor.js
@@ -26,21 +26,18 @@ export default () => (
       name="Anchor"
       availableAt={[
         {
-          url:
-            'https://storybook.grommet.io/?selectedKind=Controls-Anchor&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?selectedKind=Controls-Anchor&full=0&stories=1&panelRight=0',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',
         },
         {
-          url:
-            'https://codesandbox.io/s/github/grommet/grommet-sandbox?initialpath=/anchor&module=%2Fsrc%2FAnchor.js',
+          url: 'https://codesandbox.io/s/github/grommet/grommet-sandbox?initialpath=/anchor&module=%2Fsrc%2FAnchor.js',
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',
           label: 'CodeSandbox',
         },
         {
-          url:
-            'https://github.com/grommet/grommet/tree/master/src/js/components/Anchor',
+          url: 'https://github.com/grommet/grommet/tree/master/src/js/components/Anchor',
           label: 'Github',
         },
       ]}
@@ -99,6 +96,9 @@ export default () => (
           </PropertyValue>
           <PropertyValue type="function">
             <Example>{`() => {}`}</Example>
+          </PropertyValue>
+          <PropertyValue type="component">
+            <Example>{`{Component}`}</Example>
           </PropertyValue>
         </Property>
 


### PR DESCRIPTION
This PR aims to:
- add to the `as` prop documentation for `Anchor`
- add a component example for `as` prop