### PR TITLE
place a box around dateinput

### DIFF
--- a/src/screens/DateInput.js
+++ b/src/screens/DateInput.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DateInput } from 'grommet';
+import { Box, DateInput } from 'grommet';
 import Page from '../components/Page';
 import Item from './Components/Item';
 import {
@@ -209,7 +209,9 @@ export default DateInputPage;
 
 export const DateInputItem = ({ name, path }) => (
   <Item name={name} path={path} center pad={{ horizontal: 'xlarge' }}>
-    <DateInput format="mm/dd/yyyy" disabled />
+    <Box>
+      <DateInput format="mm/dd/yyyy" disabled />
+    </Box>
   </Item>
 );
 


### PR DESCRIPTION
Place a `box` around `dateinput` so `dateinput` doesnt grow

Currently: 
<img width="448" alt="Screen Shot 2022-03-04 at 12 00 16 PM" src="https://user-images.githubusercontent.com/42451602/156825390-f7bcf415-6ca8-4240-a7f7-861943bec1ac.png">


FIx:
<img width="400" alt="Screen Shot 2022-03-04 at 11 59 36 AM" src="https://user-images.githubusercontent.com/42451602/156825269-c8669b60-6811-462c-9c9b-7c1fa151198f.png">

