### PR TITLE
Update Select docs to show valueLabel can be a function

### DIFF
--- a/src/screens/Select.js
+++ b/src/screens/Select.js
@@ -492,6 +492,12 @@ const SelectPage = () => (
           <PropertyValue type="node">
             <Example>{`<Box>...</Box>`}</Example>
           </PropertyValue>
+          <PropertyValue type="function">
+            <Description>
+              A function that returns either a string or a React node.
+            </Description>
+            <Example>{`{(option) => {}}`}</Example>
+          </PropertyValue>
         </Property>
 
         <Property name="valueKey">
@@ -506,20 +512,24 @@ const SelectPage = () => (
             </Description>
             <Example>"key"</Example>
           </PropertyValue>
-          <PropertyValue type="function">
+          <PropertyValue type="object">
             <Description>
-              If a function is provided, it is called with the option and should
-              return the value. If reduce is true, this value will be used for
-              the 'value' delivered via 'onChange'.
+              If reduce is true, this value will be used for the 'value'
+              delivered via 'onChange'.
             </Description>
-            <Example>
-              {`
+            <Example>{`
 {
   key: "string",
   reduce: boolean
 }
-            `}
-            </Example>
+            `}</Example>
+          </PropertyValue>
+          <PropertyValue type="function">
+            <Description>
+              If a function is provided, it is called with the option and should
+              return the value.
+            </Description>
+            <Example>{`(option) => { return "string" }`}</Example>
           </PropertyValue>
         </Property>
 

--- a/src/screens/Select.js
+++ b/src/screens/Select.js
@@ -529,7 +529,7 @@ const SelectPage = () => (
               If a function is provided, it is called with the option and should
               return the value.
             </Description>
-            <Example>{`(option) => { return "string" }`}</Example>
+            <Example>{`(option) => {}`}</Example>
           </PropertyValue>
         </Property>
 


### PR DESCRIPTION
Add function as an option for `valueLabel` and fix `valueKey` doc to show both object and function as options.

Associated grommet PR: https://github.com/grommet/grommet/pull/6020