### PR TITLE
Remove Internet Explorer from supported browser list

### DIFF
--- a/src/screens/Docs/Browsers.js
+++ b/src/screens/Docs/Browsers.js
@@ -17,8 +17,6 @@ const children = `
   Mozilla Firefox, latest version
   
   Microsoft Edge, latest version
-  
-  Microsoft Internet Explorer Version 11, latest version
 `;
 
 const Browsers = () => (


### PR DESCRIPTION
Internet Explorer's end of life is June 15, 2022. We should remove it from the list of browsers we support