### PR TITLE
Fix typo in DataChart granularity

### DIFF
--- a/src/screens/DataChart.js
+++ b/src/screens/DataChart.js
@@ -203,7 +203,7 @@ const DataChartPage = () => (
             `}
             </Example>
             <PropOptions prop="granularity">
-              <Example>"course"</Example>
+              <Example>"coarse"</Example>
               <Example>"medium"</Example>
               <Example>"fine"</Example>
             </PropOptions>


### PR DESCRIPTION
Discovered while trying example at:
https://v2.grommet.io/datachart