### PR TITLE
Add doc changes for PR's before grommet release

### DIFF
--- a/src/screens/Box.js
+++ b/src/screens/Box.js
@@ -565,6 +565,9 @@ const BoxPage = () => (
             The DOM tag or react component to use for the element.
           </Description>
           <GenericAs />
+          <PropertyValue type="element">
+            <Example>{`<span />`}</Example>
+          </PropertyValue>
         </Property>
 
         <Property name="width">

--- a/src/screens/DataTable.js
+++ b/src/screens/DataTable.js
@@ -632,6 +632,26 @@ const DataTablePage = () => (
             <Example defaultValue>50</Example>
           </PropertyValue>
         </Property>
+
+        <Property name="verticalAlign">
+          <Description>How to vertically align items.</Description>
+          <PropertyValue type="string">
+            <Example>"bottom"</Example>
+            <Example>"middle"</Example>
+            <Example>"top"</Example>
+          </PropertyValue>
+          <PropertyValue type="object">
+            <Example>
+              {`
+{
+  header: "string",
+  body: "string",
+  footer: "string"
+}
+              `}
+            </Example>
+          </PropertyValue>
+        </Property>
       </Properties>
 
       <ThemeDoc>

--- a/src/screens/DataTable.js
+++ b/src/screens/DataTable.js
@@ -192,8 +192,7 @@ const DataTablePage = () => (
               first column will be used. 'pin' indicates that this column should
               not scroll out of view to the left when the table is scrolled
               horizontally. 'plain' = true indicates that the body cells in the
-              column will not apply pad. Setting `verticalAlign` within columns
-              is deprecated, the `verticalAlign` prop should be used instead.
+              column will not apply pad.
             </Description>
             <Example>
               {`

--- a/src/screens/DataTable.js
+++ b/src/screens/DataTable.js
@@ -192,7 +192,8 @@ const DataTablePage = () => (
               first column will be used. 'pin' indicates that this column should
               not scroll out of view to the left when the table is scrolled
               horizontally. 'plain' = true indicates that the body cells in the
-              column will not apply pad.
+              column will not apply pad. Setting `verticalAlign` within columns
+              is deprecated, the `verticalAlign` prop should be used instead.
             </Description>
             <Example>
               {`


### PR DESCRIPTION
Added necessary doc updates before releasing next version of grommet. Changes are related to the following pull requests:
https://github.com/grommet/grommet/pull/6038 - Make `as` prop on Box accept any React element
https://github.com/grommet/grommet/pull/6076 - Allow DataTable vertical align to be specified by prop