### PR TITLE
Remove links to medium and codesandbox for all components

### DIFF
--- a/src/screens/Docs/Resources.js
+++ b/src/screens/Docs/Resources.js
@@ -14,15 +14,9 @@ const children = `
 End-to-end project examples on the [#i-made-this][slack] channel on [slack][slack].
 
 Browse grommet component library on [Storybook][storybook].
- 
-Basic [codesandbox][playground] for each component.
-
-Read more from the Grommet team on [Medium][medium].
 
 Find us on [Twitter][twitter].
 
-[medium]: https://medium.com/grommet-io
-[playground]: https://codesandbox.io/s/github/grommet/grommet-sandbox
 [sandboxes]: https://codesandbox.io/u/grommetux/sandboxes
 [slack]: https://slack-invite.grommet.io
 [storybook]: https://storybook.grommet.io


### PR DESCRIPTION
Removed links to medium since we haven't been posting articles here in the past few years and also removed the link to codesandbox for every grommet component since we are moving away from using this and haven't kept it up to date when new components are added.