### PR TITLE
Fix Button plain description to match actual behavior of plain button

### DIFF
--- a/src/screens/Button.js
+++ b/src/screens/Button.js
@@ -429,10 +429,9 @@ const ButtonPage = () => (
         <Property name="plain">
           <Description>
             Whether this is a plain button with no border or pad. Non plain
-            button will show both pad and border. The plain button has no border
-            and unless the icon prop exist it has no pad as well. When using the
-            kind button (i.e. button.default on the theme), the usage of plain
-            is deprecated.
+            button will show both pad and border. When using the kind button
+            (i.e. button.default on the theme), the usage of plain is
+            deprecated.
           </Description>
           <GenericBoolFalse />
         </Property>


### PR DESCRIPTION
This PR changes the description of the Button `plain` prop to better align with the actual behavior of how the plain prop is working.

Currently the docs says "The plain button has no border and unless the icon prop exist it has no pad as well". This isn't how the plain prop is currently working on Grommet. Even if Button plain has and icon it will not have padding.