### PR TITLE
Added `tabs.step` prop to the Tabs theme doc

### DIFF
--- a/src/screens/Tabs.js
+++ b/src/screens/Tabs.js
@@ -249,6 +249,24 @@ const TabsPage = () => (
           <Description>Any additional style for Tabs panel.</Description>
           <GenericExtend />
         </Property>
+
+        <Property name="tabs.step">
+          <Description>
+            The number of tabs to advance or move back by when the left and
+            right arrows are visible and there is not enough room to display all
+            of the tabs on the screen. The sizes correspond to the responsive
+            breakpoint screen sizes.
+          </Description>
+          <PropertyValue type="object">
+            <Example defaultValue>{`
+step: {
+  small: 1;
+  medium: 3;
+  large: 3;
+};
+            `}</Example>
+          </PropertyValue>
+        </Property>
       </ThemeDoc>
     </ComponentDoc>
 


### PR DESCRIPTION
The [responsive tabs](https://github.com/grommet/grommet/pull/6137) pull request on Grommet added the theme prop `tabs.step`. This pull request updates the docs to reflect this addition.