### PR TITLE
Clarify that any Button prop can be passed to DropButton

### DIFF
--- a/src/screens/DropButton.js
+++ b/src/screens/DropButton.js
@@ -48,6 +48,10 @@ const DropButtonPage = () => (
     <Box pad="large" background="light-2" />
   }
 />`}
+      isA={{
+        base: 'Button',
+        path: '/button',
+      }}
     >
       <Properties>
         <Property name="a11yTitle">


### PR DESCRIPTION
It isn't clear in the doc for DropButton that Button props can be passed to DropButton. This PR adds a section that tells users that DropButton is a Button and links to the Button documentation


<img width="1272" alt="Screen Shot 2022-06-24 at 4 11 02 PM" src="https://user-images.githubusercontent.com/54560994/175699500-adc04042-9284-44aa-9533-9880776b699c.png">

