### PR TITLE
Update docs 

### DIFF
--- a/src/screens/Button.js
+++ b/src/screens/Button.js
@@ -677,18 +677,24 @@ const ButtonPage = () => (
         <Property name="button.active.default">
           <Description>
             Adjustments to the default Button style when the Button is active.
+            Any valid Button props.
           </Description>
           <PropertyValue type="object">
-            <Example>{`{}`}</Example>
-          </PropertyValue>
-        </Property>
-
-        <Property name="button.active.default.icon">
-          <Description>
-            Any specific icon in a active default Button.
-          </Description>
-          <PropertyValue type="element">
-            <Example>{`<Add />`}</Example>
+            <Example>{`{ default: {
+         background: string | object,
+         border: string | object | array,
+         color:  string | object,
+         font: {
+           weight: string | number,
+         },
+         icon: element,
+         padding: {
+           vertical: string,
+           horizontal: string,
+         },
+         reverse: boolean,
+         extend: any css,
+       },}`}</Example>
           </PropertyValue>
         </Property>
 
@@ -699,16 +705,21 @@ const ButtonPage = () => (
             button.default.
           </Description>
           <PropertyValue type="object">
-            <Example>{`{}`}</Example>
-          </PropertyValue>
-        </Property>
-
-        <Property name="button.active.primary.icon">
-          <Description>
-            Any specific icon in a active primary Button.
-          </Description>
-          <PropertyValue type="element">
-            <Example>{`<Add />`}</Example>
+            <Example>{`{ primary: {
+         background: string | object,
+         border: string | object | array,
+         color:  string | object,
+         font: {
+           weight: string | number,
+         },
+         icon: element,
+         padding: {
+           vertical: string,
+           horizontal: string,
+         },
+         reverse: boolean,
+         extend: any css,
+       },}`}</Example>
           </PropertyValue>
         </Property>
 
@@ -719,16 +730,21 @@ const ButtonPage = () => (
             button.default.
           </Description>
           <PropertyValue type="object">
-            <Example>{`{}`}</Example>
-          </PropertyValue>
-        </Property>
-
-        <Property name="button.active.secondary.icon">
-          <Description>
-            Any specific icon in a active secondary Button.
-          </Description>
-          <PropertyValue type="element">
-            <Example>{`<Add />`}</Example>
+            <Example>{`{ secondary: {
+         background: string | object,
+         border: string | object | array,
+         color:  string | object,
+         font: {
+           weight: string | number,
+         },
+         icon: element,
+         padding: {
+           vertical: string,
+           horizontal: string,
+         },
+         reverse: boolean,
+         extend: any css,
+       },}`}</Example>
           </PropertyValue>
         </Property>
 

--- a/src/screens/Button.js
+++ b/src/screens/Button.js
@@ -680,7 +680,7 @@ const ButtonPage = () => (
             Any valid Button props.
           </Description>
           <PropertyValue type="object">
-            <Example>{`{ default: {
+            <Example>{`{
          background: string | object,
          border: string | object | array,
          color:  string | object,
@@ -694,7 +694,7 @@ const ButtonPage = () => (
          },
          reverse: boolean,
          extend: any css,
-       },}`}</Example>
+       }`}</Example>
           </PropertyValue>
         </Property>
 
@@ -705,7 +705,7 @@ const ButtonPage = () => (
             button.default.
           </Description>
           <PropertyValue type="object">
-            <Example>{`{ primary: {
+            <Example>{`{
          background: string | object,
          border: string | object | array,
          color:  string | object,
@@ -719,7 +719,7 @@ const ButtonPage = () => (
          },
          reverse: boolean,
          extend: any css,
-       },}`}</Example>
+       }`}</Example>
           </PropertyValue>
         </Property>
 
@@ -730,7 +730,7 @@ const ButtonPage = () => (
             button.default.
           </Description>
           <PropertyValue type="object">
-            <Example>{`{ secondary: {
+            <Example>{`{
          background: string | object,
          border: string | object | array,
          color:  string | object,
@@ -744,7 +744,7 @@ const ButtonPage = () => (
          },
          reverse: boolean,
          extend: any css,
-       },}`}</Example>
+       }`}</Example>
           </PropertyValue>
         </Property>
 
@@ -890,15 +890,6 @@ const ButtonPage = () => (
           <GenericExtend />
         </Property>
 
-        <Property name="button.default.icon">
-          <Description>
-            Any specific icon in a button default Button.
-          </Description>
-          <PropertyValue type="element">
-            <Example>{`<Add />`}</Example>
-          </PropertyValue>
-        </Property>
-
         <Property name="button.default.padding.horizontal">
           <Description>
             The horizontal padding for a default button.
@@ -955,15 +946,6 @@ const ButtonPage = () => (
           </PropertyValue>
         </Property>
 
-        <Property name="button.disabled.default.icon">
-          <Description>
-            Any specific icon in a disabled default Button.
-          </Description>
-          <PropertyValue type="element">
-            <Example>{`<Add />`}</Example>
-          </PropertyValue>
-        </Property>
-
         <Property name="button.disabled.primary">
           <Description>
             Adjustments to the primary Button style when the Button is disabled.
@@ -975,15 +957,6 @@ const ButtonPage = () => (
           </PropertyValue>
         </Property>
 
-        <Property name="button.disabled.primary.icon">
-          <Description>
-            Any specific icon in a disabled primary Button.
-          </Description>
-          <PropertyValue type="element">
-            <Example>{`<Add />`}</Example>
-          </PropertyValue>
-        </Property>
-
         <Property name="button.disabled.secondary">
           <Description>
             Adjustments to the secondary Button style when the Button is
@@ -992,15 +965,6 @@ const ButtonPage = () => (
           </Description>
           <PropertyValue type="object">
             <Example>{`{}`}</Example>
-          </PropertyValue>
-        </Property>
-
-        <Property name="button.disabled.secondary.icon">
-          <Description>
-            Any specific icon in a disabled secondary Button.
-          </Description>
-          <PropertyValue type="element">
-            <Example>{`<Add />`}</Example>
           </PropertyValue>
         </Property>
 
@@ -1037,15 +1001,6 @@ const ButtonPage = () => (
           </PropertyValue>
         </Property>
 
-        <Property name="button.hover.default.icon">
-          <Description>
-            Any specific icon in a hover default Button.
-          </Description>
-          <PropertyValue type="element">
-            <Example>{`<Add />`}</Example>
-          </PropertyValue>
-        </Property>
-
         <Property name="button.hover.primary">
           <Description>
             Adjustments to the primary Button style when the Button is hovered.
@@ -1057,15 +1012,6 @@ const ButtonPage = () => (
           </PropertyValue>
         </Property>
 
-        <Property name="button.hover.primary.icon">
-          <Description>
-            Any specific icon in a hover primary Button.
-          </Description>
-          <PropertyValue type="element">
-            <Example>{`<Add />`}</Example>
-          </PropertyValue>
-        </Property>
-
         <Property name="button.hover.secondary">
           <Description>
             Adjustments to the secondary Button style when the Button is
@@ -1074,15 +1020,6 @@ const ButtonPage = () => (
           </Description>
           <PropertyValue type="object">
             <Example>{`{}`}</Example>
-          </PropertyValue>
-        </Property>
-
-        <Property name="button.hover.secondary.icon">
-          <Description>
-            Any specific icon in a hover secondary Button.
-          </Description>
-          <PropertyValue type="element">
-            <Example>{`<Add />`}</Example>
           </PropertyValue>
         </Property>
 
@@ -1127,15 +1064,6 @@ const ButtonPage = () => (
         <Property name="button.primary.color">
           <Description>The color of the label for primary buttons.</Description>
           <GenericColor />
-        </Property>
-
-        <Property name="button.primary.icon">
-          <Description>
-            Any specific icon in a button primary Button.
-          </Description>
-          <PropertyValue type="element">
-            <Example>{`<Add />`}</Example>
-          </PropertyValue>
         </Property>
 
         <Property name="button.primary.font.weight">
@@ -1196,15 +1124,6 @@ const ButtonPage = () => (
             themes that have defined a value for button.default.
           </Description>
           <GenericColor />
-        </Property>
-
-        <Property name="button.secondary.icon">
-          <Description>
-            Any specific icon in a button secondary Button.
-          </Description>
-          <PropertyValue type="element">
-            <Example>{`<Add />`}</Example>
-          </PropertyValue>
         </Property>
 
         <Property name="button.secondary.font.weight">

--- a/src/screens/Button.js
+++ b/src/screens/Button.js
@@ -683,6 +683,15 @@ const ButtonPage = () => (
           </PropertyValue>
         </Property>
 
+        <Property name="button.active.default.icon">
+          <Description>
+            Any specific icon in a active default Button.
+          </Description>
+          <PropertyValue type="element">
+            <Example>{`<Add />`}</Example>
+          </PropertyValue>
+        </Property>
+
         <Property name="button.active.primary">
           <Description>
             Adjustments to the primary Button style when the Button is active.
@@ -694,6 +703,15 @@ const ButtonPage = () => (
           </PropertyValue>
         </Property>
 
+        <Property name="button.active.primary.icon">
+          <Description>
+            Any specific icon in a active primary Button.
+          </Description>
+          <PropertyValue type="element">
+            <Example>{`<Add />`}</Example>
+          </PropertyValue>
+        </Property>
+
         <Property name="button.active.secondary">
           <Description>
             Adjustments to the secondary Button style when the Button is active.
@@ -702,6 +720,15 @@ const ButtonPage = () => (
           </Description>
           <PropertyValue type="object">
             <Example>{`{}`}</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="button.active.secondary.icon">
+          <Description>
+            Any specific icon in a active secondary Button.
+          </Description>
+          <PropertyValue type="element">
+            <Example>{`<Add />`}</Example>
           </PropertyValue>
         </Property>
 
@@ -847,6 +874,15 @@ const ButtonPage = () => (
           <GenericExtend />
         </Property>
 
+        <Property name="button.default.icon">
+          <Description>
+            Any specific icon in a button default Button.
+          </Description>
+          <PropertyValue type="element">
+            <Example>{`<Add />`}</Example>
+          </PropertyValue>
+        </Property>
+
         <Property name="button.default.padding.horizontal">
           <Description>
             The horizontal padding for a default button.
@@ -903,6 +939,15 @@ const ButtonPage = () => (
           </PropertyValue>
         </Property>
 
+        <Property name="button.disabled.default.icon">
+          <Description>
+            Any specific icon in a disabled default Button.
+          </Description>
+          <PropertyValue type="element">
+            <Example>{`<Add />`}</Example>
+          </PropertyValue>
+        </Property>
+
         <Property name="button.disabled.primary">
           <Description>
             Adjustments to the primary Button style when the Button is disabled.
@@ -914,6 +959,15 @@ const ButtonPage = () => (
           </PropertyValue>
         </Property>
 
+        <Property name="button.disabled.primary.icon">
+          <Description>
+            Any specific icon in a disabled primary Button.
+          </Description>
+          <PropertyValue type="element">
+            <Example>{`<Add />`}</Example>
+          </PropertyValue>
+        </Property>
+
         <Property name="button.disabled.secondary">
           <Description>
             Adjustments to the secondary Button style when the Button is
@@ -922,6 +976,15 @@ const ButtonPage = () => (
           </Description>
           <PropertyValue type="object">
             <Example>{`{}`}</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="button.disabled.secondary.icon">
+          <Description>
+            Any specific icon in a disabled secondary Button.
+          </Description>
+          <PropertyValue type="element">
+            <Example>{`<Add />`}</Example>
           </PropertyValue>
         </Property>
 
@@ -958,6 +1021,15 @@ const ButtonPage = () => (
           </PropertyValue>
         </Property>
 
+        <Property name="button.hover.default.icon">
+          <Description>
+            Any specific icon in a hover default Button.
+          </Description>
+          <PropertyValue type="element">
+            <Example>{`<Add />`}</Example>
+          </PropertyValue>
+        </Property>
+
         <Property name="button.hover.primary">
           <Description>
             Adjustments to the primary Button style when the Button is hovered.
@@ -969,6 +1041,15 @@ const ButtonPage = () => (
           </PropertyValue>
         </Property>
 
+        <Property name="button.hover.primary.icon">
+          <Description>
+            Any specific icon in a hover primary Button.
+          </Description>
+          <PropertyValue type="element">
+            <Example>{`<Add />`}</Example>
+          </PropertyValue>
+        </Property>
+
         <Property name="button.hover.secondary">
           <Description>
             Adjustments to the secondary Button style when the Button is
@@ -977,6 +1058,15 @@ const ButtonPage = () => (
           </Description>
           <PropertyValue type="object">
             <Example>{`{}`}</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="button.hover.secondary.icon">
+          <Description>
+            Any specific icon in a hover secondary Button.
+          </Description>
+          <PropertyValue type="element">
+            <Example>{`<Add />`}</Example>
           </PropertyValue>
         </Property>
 
@@ -1021,6 +1111,15 @@ const ButtonPage = () => (
         <Property name="button.primary.color">
           <Description>The color of the label for primary buttons.</Description>
           <GenericColor />
+        </Property>
+
+        <Property name="button.primary.icon">
+          <Description>
+            Any specific icon in a button primary Button.
+          </Description>
+          <PropertyValue type="element">
+            <Example>{`<Add />`}</Example>
+          </PropertyValue>
         </Property>
 
         <Property name="button.primary.font.weight">
@@ -1081,6 +1180,15 @@ const ButtonPage = () => (
             themes that have defined a value for button.default.
           </Description>
           <GenericColor />
+        </Property>
+
+        <Property name="button.secondary.icon">
+          <Description>
+            Any specific icon in a button secondary Button.
+          </Description>
+          <PropertyValue type="element">
+            <Example>{`<Add />`}</Example>
+          </PropertyValue>
         </Property>
 
         <Property name="button.secondary.font.weight">

--- a/src/screens/CheckBox.js
+++ b/src/screens/CheckBox.js
@@ -353,6 +353,11 @@ const CheckBoxPage = () => (
             <Example defaultValue>"48px"</Example>
           </PropertyValue>
         </Property>
+
+        <Property name="formField.checkBox.pad">
+          <Description>The CheckBox pad when wrapped in FormField.</Description>
+          <GenericPad />
+        </Property>
       </ThemeDoc>
     </ComponentDoc>
   </Page>

--- a/src/screens/FormField.js
+++ b/src/screens/FormField.js
@@ -7,6 +7,7 @@ import {
   GenericA11yTitle,
   GenericBool,
   GenericMargin,
+  GenericPad,
   SizesXsmallXlarge,
 } from '../utils/genericPropExamples';
 
@@ -284,6 +285,11 @@ const FormFieldPage = () => (
           <PropertyValue type="string">
             <Example defaultValue>"bottom"</Example>
           </PropertyValue>
+        </Property>
+
+        <Property name="formField.checkBox.pad">
+          <Description>The CheckBox pad when wrapped in FormField.</Description>
+          <GenericPad />
         </Property>
 
         <Property name="formField.content.margin">

--- a/src/screens/Heading.js
+++ b/src/screens/Heading.js
@@ -160,7 +160,7 @@ const HeadingPage = () => (
         <Property name="weight">
           <Description>Font weight</Description>
           <PropertyValue type="string">
-            <Example>"normal"</Example>
+            <Example defaultValue>"normal"</Example>
             <Example>"bold"</Example>
             <Example>"lighter"</Example>
             <Example>"bolder"</Example>

--- a/src/screens/Heading.js
+++ b/src/screens/Heading.js
@@ -156,6 +156,19 @@ const HeadingPage = () => (
           </Description>
           <GenericBoolFalse />
         </Property>
+
+        <Property name="weight">
+          <Description>Font weight</Description>
+          <PropertyValue type="string">
+            <Example>"normal"</Example>
+            <Example>"bold"</Example>
+            <Example>"lighter"</Example>
+            <Example>"bolder"</Example>
+          </PropertyValue>
+          <PropertyValue type="number">
+            <Example>300</Example>
+          </PropertyValue>
+        </Property>
       </Properties>
 
       <ThemeDoc>

--- a/src/screens/Menu.js
+++ b/src/screens/Menu.js
@@ -302,20 +302,6 @@ const MenuPage = () => (
           </PropertyValue>
         </Property>
 
-        <Property name="menu.icons.color">
-          <Description>The color to use for the icon.</Description>
-          <PropertyValue type="string">
-            <Description>A hex, name, or rgb value.</Description>
-            <Example defaultValue>"control"</Example>
-          </PropertyValue>
-          <PropertyValue type="object">
-            <Description>
-              An object with a color for dark and light modes.
-            </Description>
-            <Example>{`{ dark: "string", light: "string" }`}</Example>
-          </PropertyValue>
-        </Property>
-
         <Property name="menu.background">
           <Description>
             The color for the background of the menu Drop when it is open.
@@ -373,15 +359,6 @@ const MenuPage = () => (
           </PropertyValue>
         </Property>
 
-        <Property name="menu.group.separator.size">
-          <Description>
-            The thickness of the separator line between grouped items.
-          </Description>
-          <PropertyValue defaultValue type="string">
-            <Example>"xsmall"</Example>
-          </PropertyValue>
-        </Property>
-
         <Property name="menu.group.separator.pad">
           <Description>
             The padding around the separator line between grouped items.
@@ -396,6 +373,20 @@ const MenuPage = () => (
   vertical: 'none'
 }`}
             </Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="menu.icons.color">
+          <Description>The color to use for the icon.</Description>
+          <PropertyValue type="string">
+            <Description>A hex, name, or rgb value.</Description>
+            <Example defaultValue>"control"</Example>
+          </PropertyValue>
+          <PropertyValue type="object">
+            <Description>
+              An object with a color for dark and light modes.
+            </Description>
+            <Example>{`{ dark: "string", light: "string" }`}</Example>
           </PropertyValue>
         </Property>
 
@@ -414,6 +405,39 @@ const MenuPage = () => (
           </Description>
           <PropertyValue type="element">
             <Example>{`<FormUp />`}</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="menu.item">
+          <Description>Any valid Button props for the menu items.</Description>
+          <PropertyValue type="object">
+            <Example>{`{ align: 'start' }`}</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="menu.item.gap">
+          <Description>The gap between the label and icon.</Description>
+          <PropertyValue type="string">
+            <Description>
+              T-shirt sizing based off the theme or a specific size in px, em,
+              etc.
+            </Description>
+            <Example>"xxsmall"</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="menu.item.justify">
+          <Description>
+            How to align the contents within the button.
+          </Description>
+          <PropertyValue type="string">
+            <Example>"around"</Example>
+            <Example>"between"</Example>
+            <Example>"center"</Example>
+            <Example>"end"</Example>
+            <Example>"evenly"</Example>
+            <Example>"start"</Example>
+            <Example>"stretch"</Example>
           </PropertyValue>
         </Property>
       </ThemeDoc>

--- a/src/screens/Menu.js
+++ b/src/screens/Menu.js
@@ -376,6 +376,15 @@ const MenuPage = () => (
           </PropertyValue>
         </Property>
 
+        <Property name="menu.group.separator.size">
+          <Description>
+            The thickness of the separator line between grouped items.
+          </Description>
+          <PropertyValue defaultValue type="string">
+            <Example>"xsmall"</Example>
+          </PropertyValue>
+        </Property>
+
         <Property name="menu.icons.color">
           <Description>The color to use for the icon.</Description>
           <PropertyValue type="string">


### PR DESCRIPTION
This includes the latest changes to Grommet that were not added to docs.

menu.item to the docs (added in this PR https://github.com/grommet/grommet/pull/6241/files)(https://hpe.slack.com/archives/D02977518F4/p1661876566258389)
button icon kind theme stuff to the docs from this PR https://github.com/grommet/grommet/pull/6297
add `formfield.checkBox.pad` to [docs](https://github.com/grommet/grommet/pull/6300)
Add weight to Heading to [docs](https://github.com/grommet/grommet/pull/6294)