### PR TITLE
Add backgrounds theme documentation

### DIFF
--- a/src/screens/Box.js
+++ b/src/screens/Box.js
@@ -186,7 +186,9 @@ const BoxPage = () => (
   position: "bottom",
   repeat: "no-repeat",
   size: "cover",
-  image: "url(//my.com/assets/img.png)"
+  image: "url(//my.com/assets/img.png)",
+  clip: "text",
+  rotate: 45
 }
               `}
             </Example>
@@ -209,6 +211,12 @@ const BoxPage = () => (
               <Example>"cover"</Example>
               <Example>"contain"</Example>
               <Example>"string"</Example>
+            </PropOptions>
+            <PropOptions prop="clip">
+              <Example>"text"</Example>
+              <Example>"border-box"</Example>
+              <Example>"padding-box"</Example>
+              <Example>"content-box"</Example>
             </PropOptions>
           </PropertyValue>
         </Property>

--- a/src/screens/Docs/GlobalTheme.js
+++ b/src/screens/Docs/GlobalTheme.js
@@ -9,6 +9,7 @@ import {
   Example,
   ThemeDoc,
 } from '../../components/Doc';
+import RoutedAnchor from '../../components/RoutedAnchor';
 import {
   GenericExtend,
   GlobalBorderSize,
@@ -85,6 +86,41 @@ const GlobalTheme = () => (
 }
 `}
             </Example>
+          </PropertyValue>
+        </Property>
+        <Property name="global.backgrounds">
+          <Description>Backgrounds to use accross the application.</Description>
+          <Description>
+            The background's name is provided as a value a component's
+            `background` prop such as Box, Header, Page, and more.
+          </Description>
+          <PropertyValue type="object">
+            <Description disableMarkdown>
+              {`A background of one of the following types \`string\`,
+             \`{ dark: string, light: string }\` object, 
+             or `}
+              <RoutedAnchor
+                path="/box#background"
+                label="background type object"
+              />
+              .
+            </Description>
+            <Description>
+              The background may be used throughout the application by referring
+              to its name.
+            </Description>
+            <Example>{`{
+  'hero-image-3': 'url(//my.com/assets/img.png)',
+  'ambient-1': {
+    dark: 'linear-gradient()',
+    light: 'linear-gradient()'
+  },
+  'seasonal-promotion': {
+    color: 'neutral-1',
+    image: 'url(//my.com/assets/img.png)',
+    opacity: 'medium'
+  },
+}`}</Example>
           </PropertyValue>
         </Property>
         <Property name="global.borderSize">

--- a/src/screens/Drop.js
+++ b/src/screens/Drop.js
@@ -101,7 +101,9 @@ const DropPage = () => (
   opacity: true,
   repeat: "no-repeat",
   size: "cover",
-  light: "string"
+  light: "string",
+  clip: "text",
+  rotate: 45
 }
               `}
             </Example>
@@ -125,6 +127,12 @@ const DropPage = () => (
               <Example>"cover"</Example>
               <Example>"contain"</Example>
               <Example>"string"</Example>
+            </PropOptions>
+            <PropOptions prop="clip">
+              <Example>"text"</Example>
+              <Example>"border-box"</Example>
+              <Example>"padding-box"</Example>
+              <Example>"content-box"</Example>
             </PropOptions>
           </PropertyValue>
         </Property>

--- a/src/screens/Grommet.js
+++ b/src/screens/Grommet.js
@@ -70,7 +70,9 @@ const GrommetPage = () => (
   repeat: "no-repeat",
   size: "cover",
   image: "url(//my.com/assets/img.png)",
-  light: "string"
+  light: "string",
+  clip: "text",
+  rotate: 45
 }
               `}
             </Example>
@@ -93,6 +95,12 @@ const GrommetPage = () => (
               <Example>"cover"</Example>
               <Example>"contain"</Example>
               <Example>"string"</Example>
+            </PropOptions>
+            <PropOptions prop="clip">
+              <Example>"text"</Example>
+              <Example>"border-box"</Example>
+              <Example>"padding-box"</Example>
+              <Example>"content-box"</Example>
             </PropOptions>
           </PropertyValue>
         </Property>

--- a/src/screens/Layer.js
+++ b/src/screens/Layer.js
@@ -106,7 +106,9 @@ const LayerPage = () => (
   opacity: true,
   repeat: "no-repeat",
   size: "cover",
-  light: "string"
+  light: "string",
+  clip: "text",
+  rotate: 45
 }
               `}
             </Example>
@@ -130,6 +132,12 @@ const LayerPage = () => (
               <Example>"cover"</Example>
               <Example>"contain"</Example>
               <Example>"string"</Example>
+            </PropOptions>
+            <PropOptions prop="clip">
+              <Example>"text"</Example>
+              <Example>"border-box"</Example>
+              <Example>"padding-box"</Example>
+              <Example>"content-box"</Example>
             </PropOptions>
           </PropertyValue>
         </Property>

--- a/src/screens/Page.js
+++ b/src/screens/Page.js
@@ -222,7 +222,9 @@ const PagePage = () => (
   repeat: "no-repeat",
   size: "cover",
   image: "url(//my.com/assets/img.png)",
-  fill: "horizontal
+  fill: "horizontal,
+  clip: "text",
+  rotate: 45
 }
               `}
             </Example>
@@ -245,6 +247,12 @@ const PagePage = () => (
               <Example>"cover"</Example>
               <Example>"contain"</Example>
               <Example>"string"</Example>
+            </PropOptions>
+            <PropOptions prop="clip">
+              <Example>"text"</Example>
+              <Example>"border-box"</Example>
+              <Example>"padding-box"</Example>
+              <Example>"content-box"</Example>
             </PropOptions>
           </PropertyValue>
         </Property>


### PR DESCRIPTION
Adds documentation for: 
- backgrounds theme documentation
- the additional properties on the backgrounds object

Proposing we create a follow on issue to consolidate all references to BackgroundObject to a single source of truth.