### PR TITLE
Doc changes before 2.29.0 release

### DIFF
--- a/src/screens/Grommet.js
+++ b/src/screens/Grommet.js
@@ -137,19 +137,19 @@ const GrommetPage = () => (
 
         <Property name="options">
           <Description>
-            Provides a way to assign a unique id to a single DOM node.
-            Currently, this is only supported for Layer. This prop was created
-            to preserve backwards compatibility with existing behavior by
-            allowing users to opt-in to newer behavior.
+            This prop was created to preserve backwards compatibility with
+            existing behavior by allowing users to opt-in to newer behavior. Box
+            cssGap, lets users opt into using the css gap property for Box gap
+            instead of inserting an extra node into the dom to simulate a gap.
+            Layer singleId provides a way to assign a unique id to a single DOM
+            node. Currently, this is only supported for Layer.
           </Description>
           <PropertyValue type="object">
             <Example>
               {`
 {
-  layer: 
-  {
-    singleId: boolean
-  }
+  box: { cssGap: true },
+  layer: { singleId: boolean }
 }
             `}
             </Example>

--- a/src/screens/StarRating.js
+++ b/src/screens/StarRating.js
@@ -28,6 +28,7 @@ const StarRatingPage = () => (
         },
       ]}
       description="A Star Rating"
+      intrinsicElement="div"
       code="<StarRating />"
     >
       <ThemeDoc>

--- a/src/screens/ThumbsRating.js
+++ b/src/screens/ThumbsRating.js
@@ -28,6 +28,7 @@ const ThumbsRatingPage = () => (
         },
       ]}
       description="A Thumbs Rating"
+      intrinsicElement="div"
       code="<ThumbsRating />"
     >
       <ThemeDoc>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3623,7 +3623,7 @@ grommet-theme-hpe@^4.0.0:
 
 "grommet@https://github.com/grommet/grommet/tarball/stable":
   version "2.28.0"
-  resolved "https://github.com/grommet/grommet/tarball/stable#5d647bee19d5f6e745f0da417937cd52c0460390"
+  resolved "https://github.com/grommet/grommet/tarball/stable#d9f679647b8840bd86489d5cc0da75e73a5cbefd"
   dependencies:
     grommet-icons "^4.8.0"
     hoist-non-react-statics "^3.2.0"


### PR DESCRIPTION
Added doc changes for Grommet `options.box.cssGap` and added an intrinsic element for StarRating and ThumbsRating

Related to https://github.com/grommet/hpe-design-system/issues/3034