### PR TITLE
add new properties per Feb release

### DIFF
--- a/src/screens/Button.js
+++ b/src/screens/Button.js
@@ -1210,7 +1210,7 @@ const ButtonPage = () => (
             <Example>"4px"</Example>
           </PropertyValue>
           <PropertyValue type="object">
-            <Example>{`{}`}</Example>
+            <Example>{`{ horizontal: string; vertical: string }`}</Example>
           </PropertyValue>
         </Property>
 

--- a/src/screens/Button.js
+++ b/src/screens/Button.js
@@ -877,6 +877,22 @@ const ButtonPage = () => (
           <GenericColor />
         </Property>
 
+        <Property name="button.default.direction">
+          <Description>The direction of the icon + label.</Description>
+          <PropertyValue type="string">
+            <Example defaultValue>'row'</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="button.default.font.size">
+          <Description>
+            The size of the text label for default buttons.
+          </Description>
+          <PropertyValue type="string">
+            <Example defaultValue>'small'</Example>
+          </PropertyValue>
+        </Property>
+
         <Property name="button.default.font.weight">
           <Description>
             The weight of the text label for default buttons.
@@ -1035,20 +1051,6 @@ const ButtonPage = () => (
           </PropertyValue>
         </Property>
 
-        <Property name="button.[kind].direction">
-          <Description>The direction of the icon + label.</Description>
-          <PropertyValue type="string">
-            <Example defaultValue>'row'</Example>
-          </PropertyValue>
-        </Property>
-
-        <Property name="button.[kind].font.size">
-          <Description>The size of the font for button kind.</Description>
-          <PropertyValue type="string">
-            <Example defaultValue>'small'</Example>
-          </PropertyValue>
-        </Property>
-
         <Property name="button.padding.horizontal">
           <Description>The horizontal padding.</Description>
           <PropertyValue type="string">
@@ -1090,6 +1092,22 @@ const ButtonPage = () => (
         <Property name="button.primary.color">
           <Description>The color of the label for primary buttons.</Description>
           <GenericColor />
+        </Property>
+
+        <Property name="button.primary.direction">
+          <Description>The direction of the icon + label.</Description>
+          <PropertyValue type="string">
+            <Example defaultValue>'row'</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="button.primary.font.size">
+          <Description>
+            The size of the text label for primary buttons.
+          </Description>
+          <PropertyValue type="string">
+            <Example defaultValue>'small'</Example>
+          </PropertyValue>
         </Property>
 
         <Property name="button.primary.font.weight">
@@ -1150,6 +1168,22 @@ const ButtonPage = () => (
             themes that have defined a value for button.default.
           </Description>
           <GenericColor />
+        </Property>
+
+        <Property name="button.secondary.direction">
+          <Description>The direction of the icon + label.</Description>
+          <PropertyValue type="string">
+            <Example defaultValue>'row'</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="button.secondary.font.size">
+          <Description>
+            The size of the text label for secondary buttons.
+          </Description>
+          <PropertyValue type="string">
+            <Example defaultValue>'small'</Example>
+          </PropertyValue>
         </Property>
 
         <Property name="button.secondary.font.weight">

--- a/src/screens/Button.js
+++ b/src/screens/Button.js
@@ -1027,13 +1027,11 @@ const ButtonPage = () => (
             Adjustments to the icon size on different screen sizes.
           </Description>
           <PropertyValue type="object">
-            <Example>{`icon: {
-              size: {
-                small: '12px',
-                medium: '18px',
-                large: '28px',
-              },
-            },`}</Example>
+            <Example>{`{
+              small: '12px',
+              medium: '18px',
+              large: '28px',
+            }`}</Example>
           </PropertyValue>
         </Property>
 

--- a/src/screens/Button.js
+++ b/src/screens/Button.js
@@ -1243,7 +1243,7 @@ const ButtonPage = () => (
             <Example>"4px"</Example>
           </PropertyValue>
           <PropertyValue type="object">
-            <Example>{`{}`}</Example>
+            <Example>{`{ horizontal: string; vertical: string }`}</Example>
           </PropertyValue>
         </Property>
 

--- a/src/screens/Button.js
+++ b/src/screens/Button.js
@@ -1038,7 +1038,7 @@ const ButtonPage = () => (
         <Property name="button.[kind].direction">
           <Description>The direction of the icon + label.</Description>
           <PropertyValue type="string">
-            <Example defaultValue>row</Example>
+            <Example defaultValue>'row'</Example>
           </PropertyValue>
         </Property>
 

--- a/src/screens/Button.js
+++ b/src/screens/Button.js
@@ -1276,7 +1276,7 @@ const ButtonPage = () => (
             <Example>"4px"</Example>
           </PropertyValue>
           <PropertyValue type="object">
-            <Example>{`{}`}</Example>
+            <Example>{`{ horizontal: string; vertical: string }`}</Example>
           </PropertyValue>
         </Property>
 

--- a/src/screens/Button.js
+++ b/src/screens/Button.js
@@ -1022,6 +1022,28 @@ const ButtonPage = () => (
           </PropertyValue>
         </Property>
 
+        <Property name="button.icon.size">
+          <Description>
+            Adjustments to the icon size on different screen sizes.
+          </Description>
+          <PropertyValue type="object">
+            <Example>{`icon: {
+              size: {
+                small: '12px',
+                medium: '18px',
+                large: '28px',
+              },
+            },`}</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="button.[kind].direction">
+          <Description>The direction of the icon + label.</Description>
+          <PropertyValue type="string">
+            <Example defaultValue>row</Example>
+          </PropertyValue>
+        </Property>
+
         <Property name="button.padding.horizontal">
           <Description>The horizontal padding.</Description>
           <PropertyValue type="string">
@@ -1182,6 +1204,18 @@ const ButtonPage = () => (
           </PropertyValue>
         </Property>
 
+        <Property name="button.size.small.iconOnly.pad">
+          <Description>
+            Specify pad for iconOnly Buttons across button sizes.
+          </Description>
+          <PropertyValue type="string">
+            <Example>"4px"</Example>
+          </PropertyValue>
+          <PropertyValue type="object">
+            <Example>{`{}`}</Example>
+          </PropertyValue>
+        </Property>
+
         <Property name="button.size.medium.border.radius">
           <Description>The border corner radius.</Description>
           <PropertyValue type="string">
@@ -1203,6 +1237,18 @@ const ButtonPage = () => (
           </PropertyValue>
         </Property>
 
+        <Property name="button.size.medium.iconOnly.pad">
+          <Description>
+            Specify pad for iconOnly Buttons across button sizes.
+          </Description>
+          <PropertyValue type="string">
+            <Example>"4px"</Example>
+          </PropertyValue>
+          <PropertyValue type="object">
+            <Example>{`{}`}</Example>
+          </PropertyValue>
+        </Property>
+
         <Property name="button.size.large.border.radius">
           <Description>The border corner radius.</Description>
           <PropertyValue type="string">
@@ -1221,6 +1267,18 @@ const ButtonPage = () => (
           <Description>The pad</Description>
           <PropertyValue type="string">
             <Example defaultValue>"8px"</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="button.size.large.iconOnly.pad">
+          <Description>
+            Specify pad for iconOnly Buttons across button sizes.
+          </Description>
+          <PropertyValue type="string">
+            <Example>"4px"</Example>
+          </PropertyValue>
+          <PropertyValue type="object">
+            <Example>{`{}`}</Example>
           </PropertyValue>
         </Property>
 

--- a/src/screens/Button.js
+++ b/src/screens/Button.js
@@ -1042,6 +1042,13 @@ const ButtonPage = () => (
           </PropertyValue>
         </Property>
 
+        <Property name="button.[kind].font.size">
+          <Description>The size of the font for button kind.</Description>
+          <PropertyValue type="string">
+            <Example defaultValue>'small'</Example>
+          </PropertyValue>
+        </Property>
+
         <Property name="button.padding.horizontal">
           <Description>The horizontal padding.</Description>
           <PropertyValue type="string">

--- a/src/screens/Calendar.js
+++ b/src/screens/Calendar.js
@@ -328,7 +328,10 @@ const CalendarPage = () => (
         </Property>
 
         <Property name="calendar.heading.level">
-          <Description>The heading level used for the calendar.</Description>
+          <Description>
+            The alendar[size].title should be used in place of this heading
+            level used for the calendar.
+          </Description>
           <PropertyValue type="number">
             <Example defaultValue>4</Example>
           </PropertyValue>

--- a/src/screens/Calendar.js
+++ b/src/screens/Calendar.js
@@ -329,7 +329,7 @@ const CalendarPage = () => (
 
         <Property name="calendar.heading.level">
           <Description>
-            The alendar[size].title should be used in place of this heading
+            The Calendar[size].title should be used in place of this heading
             level used for the calendar.
           </Description>
           <PropertyValue type="number">

--- a/src/screens/Calendar.js
+++ b/src/screens/Calendar.js
@@ -401,6 +401,15 @@ const CalendarPage = () => (
           </PropertyValue>
         </Property>
 
+        <Property name="calendar.large.title">
+          <Description>
+            Any valid Text prop for the calendar text heading when large.
+          </Description>
+          <PropertyValue type="object">
+            <Example defaultValue> {`{}`} </Example>
+          </PropertyValue>
+        </Property>
+
         <Property name="calendar.medium.daySize">
           <Description>The size of a day when medium.</Description>
           <PropertyValue type="string">
@@ -433,6 +442,15 @@ const CalendarPage = () => (
           </PropertyValue>
         </Property>
 
+        <Property name="calendar.medium.title">
+          <Description>
+            Any valid Text prop for the calendar text heading when medium.
+          </Description>
+          <PropertyValue type="object">
+            <Example defaultValue> {`{}`} </Example>
+          </PropertyValue>
+        </Property>
+
         <Property name="calendar.small.daySize">
           <Description>The size of a day when small.</Description>
           <PropertyValue type="string">
@@ -460,6 +478,15 @@ const CalendarPage = () => (
           </Description>
           <PropertyValue type="string">
             <Example defaultValue>"0.2s"</Example>
+          </PropertyValue>
+        </Property>
+
+        <Property name="calendar.small.title">
+          <Description>
+            Any valid Text prop for the calendar text heading when small.
+          </Description>
+          <PropertyValue type="object">
+            <Example defaultValue> {`{}`} </Example>
           </PropertyValue>
         </Property>
 

--- a/src/screens/DataSearch.js
+++ b/src/screens/DataSearch.js
@@ -2,7 +2,14 @@ import React from 'react';
 import { Data, DataSearch, Toolbar } from 'grommet';
 import Page from '../components/Page';
 import Item from './Components/Item';
-import { ComponentDoc } from '../components/Doc';
+import {
+  ComponentDoc,
+  Properties,
+  Property,
+  PropertyValue,
+  Description,
+  Example,
+} from '../components/Doc';
 
 const DataSearchPage = () => (
   <Page>
@@ -24,6 +31,24 @@ const DataSearchPage = () => (
   <DataTable />
 </Data>`}
     />
+
+    <Properties>
+      <Property name="drop">
+        <Description>Whether to show the search via a DropButton.</Description>
+        <PropertyValue type="boolean">
+          <Example>true</Example>
+        </PropertyValue>
+      </Property>
+    </Properties>
+
+    <Properties>
+      <Property name="responsive">
+        <Description>Whether the serach is responsive.</Description>
+        <PropertyValue type="boolean">
+          <Example>true</Example>
+        </PropertyValue>
+      </Property>
+    </Properties>
   </Page>
 );
 

--- a/src/screens/Layer.js
+++ b/src/screens/Layer.js
@@ -295,6 +295,15 @@ const LayerPage = () => (
           <GenericExtend />
         </Property>
 
+        <Property name="layer.overlay.backdopFilter">
+          <Description>
+            The backdrop-filter which takes any CSS supporrtted string value.
+          </Description>
+          <PropertyValue type="string">
+            <Example>"blur(12px)"</Example>
+          </PropertyValue>
+        </Property>
+
         <Property name="layer.overlay.background">
           <Description>The background of the Layer overlay.</Description>
           <PropertyValue type="string">

--- a/src/screens/TextInput.js
+++ b/src/screens/TextInput.js
@@ -314,6 +314,23 @@ const TextInputPage = () => (
             <Example>0</Example>
           </PropertyValue>
         </Property>
+
+        <Property name="width">
+          <Description>A fixed width.</Description>
+          <PropertyValue type="string">
+            <Description>
+              T-shirt sizing based off the theme or a specific size in px, em,
+              etc.
+            </Description>
+            <Example>"xxsmall"</Example>
+            <SizesXsmallXlarge />
+            <Example>"xxlarge"</Example>
+            <Example>"any CSS size"</Example>
+          </PropertyValue>
+          <PropertyValue type="object">
+            <Example>{`{ min: "...", max: "..." }`}</Example>
+          </PropertyValue>
+        </Property>
       </Properties>
 
       <ThemeDoc>


### PR DESCRIPTION
The following PR adds: 

`width` for [TextInput](https://github.com/grommet/grommet/pull/6624)
`button.icon.size` for [Button](https://www.google.com/url?q=https://github.com/grommet/grommet/pull/6604&sa=D&source=docs&ust=1676574010377036&usg=AOvVaw0sxHqv4KFkvmEFDIaL2a3F)
`button.size.small.iconOnly.pad` for [Button](https://www.google.com/url?q=https://github.com/grommet/grommet/pull/6604&sa=D&source=docs&ust=1676574010377036&usg=AOvVaw0sxHqv4KFkvmEFDIaL2a3F)
`button.[kind].direction` for [Button](https://www.google.com/url?q=https://github.com/grommet/grommet/pull/6606&sa=D&source=docs&ust=1676573957254960&usg=AOvVaw3uCEkvmb2MJc_7zENq7J5A)
`ayer.overlay.backdopFilter` for [Layer](https://github.com/grommet/grommet/pull/6605)