### PR TITLE
Update storybook links

### DIFF
--- a/src/screens/Accordion.js
+++ b/src/screens/Accordion.js
@@ -25,7 +25,7 @@ const AccordionPage = () => (
       name="Accordion"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Controls-Accordion&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Controls-Accordion',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Anchor.js
+++ b/src/screens/Anchor.js
@@ -26,7 +26,7 @@ const AnchorPage = () => (
       name="Anchor"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Controls-Anchor&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Controls-Anchor',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/AnnounceContext.js
+++ b/src/screens/AnnounceContext.js
@@ -17,7 +17,7 @@ const AnnounceContextPage = () => (
       name="Announce Context .Consumer"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Utilities-AnnounceContext&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Utilities-AnnounceContext',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Avatar.js
+++ b/src/screens/Avatar.js
@@ -20,7 +20,7 @@ const AvatarPage = () => (
       name="Avatar"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Visualizations-Avatar&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Visualizations-Avatar',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Box.js
+++ b/src/screens/Box.js
@@ -47,7 +47,7 @@ const BoxPage = () => (
       name="Box"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Layout-Box&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Layout-Box',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Button.js
+++ b/src/screens/Button.js
@@ -42,7 +42,7 @@ const ButtonPage = () => (
       name="Button"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Controls-Button&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Controls-Button',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Calendar.js
+++ b/src/screens/Calendar.js
@@ -28,7 +28,7 @@ const CalendarPage = () => (
       name="Calendar"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Visualizations-Calendar&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Visualizations-Calendar',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Card.js
+++ b/src/screens/Card.js
@@ -20,7 +20,7 @@ const CardPage = () => (
       name="Card"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Layout-Card&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Layout-Card',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Carousel.js
+++ b/src/screens/Carousel.js
@@ -33,7 +33,7 @@ const CarouselPage = () => (
       name="Carousel"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Media-Carousel&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Media-Carousel',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Chart.js
+++ b/src/screens/Chart.js
@@ -29,7 +29,7 @@ const ChartPage = () => (
       name="Chart"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Visualizations-Chart&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Visualizations-Chart',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/CheckBox.js
+++ b/src/screens/CheckBox.js
@@ -26,7 +26,7 @@ const CheckBoxPage = () => (
       name="CheckBox"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Input-CheckBox&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Input-CheckBox',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/CheckBoxGroup.js
+++ b/src/screens/CheckBoxGroup.js
@@ -18,7 +18,7 @@ const CheckBoxGroupPage = () => (
       name="CheckBoxGroup"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Input-CheckBoxGroup&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Input-CheckBoxGroup',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Clock.js
+++ b/src/screens/Clock.js
@@ -26,7 +26,7 @@ const ClockPage = () => (
       name="Clock"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Visualization-Clock&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Visualization-Clock',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Collapsible.js
+++ b/src/screens/Collapsible.js
@@ -21,7 +21,7 @@ const CollapsiblePage = () => (
       description="Expand or collapse animation"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Utilities-Collapsible&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Utilities-Collapsible',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Data.js
+++ b/src/screens/Data.js
@@ -120,7 +120,7 @@ const DataPage = () => (
       stable
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Layout-Footer&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Layout-Footer',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/DataChart.js
+++ b/src/screens/DataChart.js
@@ -107,7 +107,7 @@ const DataChartPage = () => (
       intrinsicElement="div"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Visualizations-DataChart&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Visualizations-DataChart',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/DataTable.js
+++ b/src/screens/DataTable.js
@@ -28,7 +28,7 @@ const DataTablePage = () => (
       name="DataTable"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Visualizations-DataTable&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Visualizations-DataTable',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/DateInput.js
+++ b/src/screens/DateInput.js
@@ -22,7 +22,7 @@ const DateInputPage = () => (
       name="DateInput"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Input-DateInput&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Input-DateInput',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Diagram.js
+++ b/src/screens/Diagram.js
@@ -32,7 +32,7 @@ const DiagramPage = () => (
       name="Diagram"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Visualizations-Diagram&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Visualizations-Diagram',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Distribution.js
+++ b/src/screens/Distribution.js
@@ -25,7 +25,7 @@ const DistributionPage = () => (
       name="Distribution"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Visualizations-Distribution&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Visualizations-Distribution',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Drop.js
+++ b/src/screens/Drop.js
@@ -29,7 +29,7 @@ const DropPage = () => (
       name="Drop"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Controls-Drop&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Controls-Drop',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/DropButton.js
+++ b/src/screens/DropButton.js
@@ -25,7 +25,7 @@ const DropButtonPage = () => (
       name="DropButton"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Controls-DropButton&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Controls-DropButton',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/FileInput.js
+++ b/src/screens/FileInput.js
@@ -27,7 +27,7 @@ const FileInputPage = () => (
       name="FileInput"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Input-FileInput&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Input-FileInput',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Footer.js
+++ b/src/screens/Footer.js
@@ -10,7 +10,7 @@ const FooterPage = () => (
       name="Footer"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Layout-Footer&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Layout-Footer',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Form.js
+++ b/src/screens/Form.js
@@ -96,7 +96,7 @@ const FormPage = () => (
       intrinsicElement="form"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Input-Form&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Input-Form',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/FormField.js
+++ b/src/screens/FormField.js
@@ -28,7 +28,7 @@ const FormFieldPage = () => (
       name="FormField"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Input-FormField&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Input-FormField',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Grid.js
+++ b/src/screens/Grid.js
@@ -49,7 +49,7 @@ const GridPage = () => (
       name="Grid"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Layout-Grid&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Layout-Grid',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Grommet.js
+++ b/src/screens/Grommet.js
@@ -21,7 +21,7 @@ const GrommetPage = () => (
       name="Grommet"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Utilities-Grommet&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Utilities-Grommet',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Header.js
+++ b/src/screens/Header.js
@@ -17,7 +17,7 @@ const HeaderPage = () => (
       name="Header"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Layout-Header&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Layout-Header',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Heading.js
+++ b/src/screens/Heading.js
@@ -32,7 +32,7 @@ const HeadingPage = () => (
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',
-          url: 'https://storybook.grommet.io/?selectedKind=Type-Heading&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Type-Heading',
         },
         {
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',

--- a/src/screens/Image.js
+++ b/src/screens/Image.js
@@ -27,7 +27,7 @@ const ImagePage = () => (
       name="Image"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Media-Image&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Media-Image',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/InfiniteScroll.js
+++ b/src/screens/InfiniteScroll.js
@@ -18,7 +18,7 @@ const InfiniteScrollPage = () => (
       name="InfiniteScroll"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Utilities-InfiniteScroll&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Utilities-InfiniteScroll',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Layer.js
+++ b/src/screens/Layer.js
@@ -28,7 +28,7 @@ const LayerPage = () => (
       name="Layer"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Layout-Layer&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Layout-Layer',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/List.js
+++ b/src/screens/List.js
@@ -27,7 +27,7 @@ const ListPage = () => (
       name="List"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Visualizations-List&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Visualizations-List',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Main.js
+++ b/src/screens/Main.js
@@ -10,7 +10,7 @@ const MainPage = () => (
       name="Main"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Layout-Main&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Layout-Main',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Markdown.js
+++ b/src/screens/Markdown.js
@@ -19,7 +19,7 @@ const MarkdownPage = () => (
       name="Markdown"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Type-Markdown&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Type-Markdown',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/MaskedInput.js
+++ b/src/screens/MaskedInput.js
@@ -34,7 +34,7 @@ const MaskedInputPage = () => (
       name="MaskedInput"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Input-MaskedInput&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Input-MaskedInput',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Menu.js
+++ b/src/screens/Menu.js
@@ -28,7 +28,7 @@ const MenuPage = () => (
       name="Menu"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Controls-Menu&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Controls-Menu',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Meter.js
+++ b/src/screens/Meter.js
@@ -32,7 +32,7 @@ const MeterPage = () => (
       name="Meter"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Visualizations-Meter&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Visualizations-Meter',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Nav.js
+++ b/src/screens/Nav.js
@@ -11,7 +11,7 @@ const NavPage = () => (
       name="Nav"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Controls-Nav&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Controls-Nav',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Page.js
+++ b/src/screens/Page.js
@@ -20,7 +20,7 @@ const PagePage = () => (
       name="Page"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Layout-Page&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Layout-Page',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/PageHeader.js
+++ b/src/screens/PageHeader.js
@@ -24,7 +24,7 @@ const PageHeaderPage = () => (
       name="PageHeader"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Layout-PageHeader&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Layout-PageHeader',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Pagination.js
+++ b/src/screens/Pagination.js
@@ -25,7 +25,7 @@ const PaginationPage = () => (
       name="Pagination"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Controls-Pagination&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Controls-Pagination',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Paragraph.js
+++ b/src/screens/Paragraph.js
@@ -32,7 +32,7 @@ const ParagraphPage = () => (
       name="Paragraph"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Type-Paragraph&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Type-Paragraph',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/RadioButton.js
+++ b/src/screens/RadioButton.js
@@ -20,7 +20,7 @@ const RadioButtonPage = () => (
       name="RadioButton"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Input-RadioButton&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Input-RadioButton',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/RadioButtonGroup.js
+++ b/src/screens/RadioButtonGroup.js
@@ -19,7 +19,7 @@ const RadioButtonGroupPage = () => (
       name="RadioButtonGroup"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Input-RadioButtonGroup&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Input-RadioButtonGroup',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/RangeInput.js
+++ b/src/screens/RangeInput.js
@@ -29,7 +29,7 @@ const RangeInputPage = () => (
       name="RangeInput"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Input-RangeInput&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Input-RangeInput',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/RangeSelector.js
+++ b/src/screens/RangeSelector.js
@@ -20,7 +20,7 @@ const RangeSelectorPage = () => (
       name="RangeSelector"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Input-RangeSelector&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Input-RangeSelector',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/ResponsiveContext.js
+++ b/src/screens/ResponsiveContext.js
@@ -22,7 +22,7 @@ const ResponsiveContextPage = () => (
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',
-          url: 'https://storybook.grommet.io/?selectedKind=undefined-ResponsiveContext&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/undefined-ResponsiveContext',
         },
         {
           badge: 'https://codesandbox.io/static/img/play-codesandbox.svg',

--- a/src/screens/Select.js
+++ b/src/screens/Select.js
@@ -29,7 +29,7 @@ const SelectPage = () => (
       name="Select"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Input-Select&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Input-Select',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/SelectMultiple.js
+++ b/src/screens/SelectMultiple.js
@@ -29,7 +29,7 @@ const SelectMultiplePage = () => (
       name="SelectMultiple"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Input-SelectMultiple&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Input-SelectMultiple',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Sidebar.js
+++ b/src/screens/Sidebar.js
@@ -17,7 +17,7 @@ const SidebarPage = () => (
       name="Sidebar"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Layout-Sidebar&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Layout-Sidebar',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Skeleton.js
+++ b/src/screens/Skeleton.js
@@ -27,7 +27,7 @@ const SkeletonPage = () => (
       name="Skeleton"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Visualizations-Skeleton&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Visualizations-Skeleton',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/SkipLinks.js
+++ b/src/screens/SkipLinks.js
@@ -25,7 +25,7 @@ const SkipLinksPage = () => (
       name="SkipLinks"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Utilities-SkipLinks&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Utilities-SkipLinks',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Spinner.js
+++ b/src/screens/Spinner.js
@@ -19,7 +19,7 @@ const SpinnerPage = () => (
       name="Spinner"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Visualizations-Spinner&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Visualizations-Spinner',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Stack.js
+++ b/src/screens/Stack.js
@@ -26,7 +26,7 @@ const StackPage = () => (
       name="Stack"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Layout-Stack&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Layout-Stack',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Table.js
+++ b/src/screens/Table.js
@@ -31,7 +31,7 @@ const TablePage = () => (
       name="Table"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Visualizations-Table&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Visualizations-Table',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Tabs.js
+++ b/src/screens/Tabs.js
@@ -28,7 +28,7 @@ const TabsPage = () => (
       name="Tabs"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Controls-Tabs&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Controls-Tabs',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Tag.js
+++ b/src/screens/Tag.js
@@ -28,7 +28,7 @@ const TagPage = () => (
       name="Tag"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Type-Tag&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Type-Tag',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Text.js
+++ b/src/screens/Text.js
@@ -27,7 +27,7 @@ const TextPage = () => (
       name="Text"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Type-Text&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Type-Text',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/TextArea.js
+++ b/src/screens/TextArea.js
@@ -32,7 +32,7 @@ const TextAreaPage = () => (
       name="TextArea"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Input-TextArea&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Input-TextArea',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/TextInput.js
+++ b/src/screens/TextInput.js
@@ -30,7 +30,7 @@ const TextInputPage = () => (
       name="TextInput"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Input-TextInput&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Input-TextInput',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/ThemeContext.js
+++ b/src/screens/ThemeContext.js
@@ -18,7 +18,7 @@ const ThemeContext = () => (
       pageTitle="ThemeContext"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=undefined-ThemeContext&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/undefined-ThemeContext',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Tip.js
+++ b/src/screens/Tip.js
@@ -19,7 +19,7 @@ const Tip = () => (
       name="Tip"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Controls-Tip&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Controls-Tip',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/Video.js
+++ b/src/screens/Video.js
@@ -27,7 +27,7 @@ const Video = () => (
       name="Video"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Media-Video&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Media-Video',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',

--- a/src/screens/WorldMap.js
+++ b/src/screens/WorldMap.js
@@ -27,7 +27,7 @@ const WorldMapDoc = () => (
       name="WorldMap"
       availableAt={[
         {
-          url: 'https://storybook.grommet.io/?selectedKind=Visualizations-WorldMap&full=0&stories=1&panelRight=0',
+          url: 'https://storybook.grommet.io/?path=/story/Visualizations-WorldMap',
           badge:
             'https://cdn-images-1.medium.com/fit/c/120/120/1*TD1P0HtIH9zF0UEH28zYtw.png',
           label: 'Storybook',


### PR DESCRIPTION
After upgrading to storybook 7 some of our links on grommet site stopped working. This PR fixes those links.

Closes https://github.com/grommet/grommet-site/issues/468