### PR TITLE
add dataSearch `as` TextInput

### DIFF
--- a/src/screens/DataSearch.js
+++ b/src/screens/DataSearch.js
@@ -29,6 +29,10 @@ const DataSearchPage = () => (
   <Toolbar><DataSearch /></Toolbar>
   <DataTable />
 </Data>`}
+      isA={{
+        base: 'TextInput',
+        path: '/textinput',
+      }}
     >
       <Properties>
         <Property name="drop">


### PR DESCRIPTION
Added in the docs that 
```
DataSearch is a [TextInput](http://localhost:8567/textinput). You can customize it using the properties available in TextInput.

```

We have this wording already so just utilized this.
In DataSearch.js in grommet we have 
```
      icon={<Search />}
      type="search"

```
for the TextInput prop however being that this is a DataSearch hence Search the keyword not sure if we should add these in the docs as default open to suggestions 