### PR TITLE
add in description for options to also take checkbox props

### DIFF
--- a/src/screens/DataTableColumns.js
+++ b/src/screens/DataTableColumns.js
@@ -46,8 +46,12 @@ const DataTableColumnsPage = () => (
             <Example>{`['id', 'name', 'age']`}</Example>
           </PropertyValue>
           <PropertyValue type="array of objects">
+            <Description>
+              An array of objects of CheckBox props excluding the 'checked'
+              property, use 'property' prop instead of 'checked'.
+            </Description>
             <Example>{`[
-  { label: 'Id', value: 'id' },
+  { label: 'Id', value: 'id', disabled: true },
   { label: 'Name', value: 'name' },
   { label: 'Age', value: 'age' },
 ]`}</Example>

--- a/src/screens/DataTableColumns.js
+++ b/src/screens/DataTableColumns.js
@@ -47,9 +47,10 @@ const DataTableColumnsPage = () => (
           </PropertyValue>
           <PropertyValue type="array of objects">
             <Description>
-              An array of objects that can include a `label`, `property` in
-              which is the value as well as any of CheckBox props excluding the
-              'checked' property, use 'property' prop instead of 'checked'.
+              An array of objects that can include a `label` which will render
+              as the option label, `property` which should be a data property,
+              and `disabled` which will determine if the option can be
+              checked/unchecked.
             </Description>
             <Example>{`[
   { label: 'Id', property: 'id', disabled: true },

--- a/src/screens/DataTableColumns.js
+++ b/src/screens/DataTableColumns.js
@@ -47,13 +47,14 @@ const DataTableColumnsPage = () => (
           </PropertyValue>
           <PropertyValue type="array of objects">
             <Description>
-              An array of objects of CheckBox props excluding the 'checked'
-              property, use 'property' prop instead of 'checked'.
+              An array of objects that can include a `label`, `property` in
+              which is the value as well as any of CheckBox props excluding the
+              'checked' property, use 'property' prop instead of 'checked'.
             </Description>
             <Example>{`[
-  { label: 'Id', value: 'id', disabled: true },
-  { label: 'Name', value: 'name' },
-  { label: 'Age', value: 'age' },
+  { label: 'Id', property: 'id', disabled: true },
+  { label: 'Name', property: 'name' },
+  { label: 'Age', property: 'age' },
 ]`}</Example>
           </PropertyValue>
         </Property>


### PR DESCRIPTION
DataTableColumns `options` prop also takes any `checkbox` props. Adding this in the description so users can know. One difference is that instead of `value` prop in CheckBox in DataTableColumns it needs a `property` passed in if an array of objects is given. 