### PR TITLE
Fix typo in Heading level documentation

### DIFF
--- a/src/screens/Heading.js
+++ b/src/screens/Heading.js
@@ -227,7 +227,7 @@ const HeadingPage = () => (
             adjustment is intended to aid readability on smaller screens but
             will not semantically affect your application structure. If you do
             not want this responsive styling to occur, you can set
-            header.responsiveBreakpoint to undefined.
+            heading.responsiveBreakpoint to undefined.
           </Description>
           <PropertyValue type="object">
             <Example>


### PR DESCRIPTION
`heading.level` documentation incorrectly references `header.responsiveBreakpoint`. This PR changes it to `heading.responsiveBreakpoint` instead.

Related slack thread:
https://grommet.slack.com/archives/C09QQEG69/p1734376393309149