### PR TITLE
chore: Twitter branding to X

### DIFF
--- a/src/screens/Docs/Resources.js
+++ b/src/screens/Docs/Resources.js
@@ -15,12 +15,12 @@ End-to-end project examples on the [#i-made-this][slack] channel on [slack][slac
 
 Browse grommet component library on [Storybook][storybook].
 
-Find us on [Twitter][twitter].
+Find us on [X (Twitter)][X (Twitter)].
 
 [sandboxes]: https://codesandbox.io/u/grommetux/sandboxes
 [slack]: https://slack-invite.grommet.io
 [storybook]: https://storybook.grommet.io
-[twitter]: https://twitter.com/grommet_io
+[x]: https://x.com/grommet_io
 `;
 
 const Resources = () => (

--- a/src/screens/Home/index.js
+++ b/src/screens/Home/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Anchor, Box, Image, Paragraph, Text } from 'grommet';
-import { Github, Slack, Twitter } from 'grommet-icons';
+import { Github, Slack, X } from 'grommet-icons';
 import Nav from '../../components/Nav';
 import Header from '../../components/Header';
 import RoutedButton from '../../components/RoutedButton';
@@ -36,10 +36,10 @@ const HomePage = () => (
       >
         <Anchor
           target="_blank"
-          a11yTitle="Follow us on Twitter"
-          href="https://twitter.com/grommet_io"
-          icon={<Twitter color="brand" size="large" />}
-          label={<Text size="large">Follow us on Twitter</Text>}
+          a11yTitle="Follow us on X (Twitter)"
+          href="https://x.com/grommet_io"
+          icon={<X color="brand" size="large" />}
+          label={<Text size="large">Follow us on X (Twitter)</Text>}
         />
         <Anchor
           target="_blank"
@@ -127,9 +127,9 @@ const HomePage = () => (
           <Box direction="row" gap="small">
             <Anchor
               target="_blank"
-              a11yTitle="Follow us on Twitter"
-              href="https://twitter.com/grommet_io"
-              icon={<Twitter color="brand" size="large" />}
+              a11yTitle="Follow us on X (Twitter)"
+              href="https://x.com/grommet_io"
+              icon={<X color="brand" size="large" />}
             />
             <Anchor
               target="_blank"

--- a/src/screens/Nav.js
+++ b/src/screens/Nav.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Anchor, Nav } from 'grommet';
-import { FacebookOption, Twitter, Github, Linkedin } from 'grommet-icons';
+import { FacebookOption, X, Github, Linkedin } from 'grommet-icons';
 import Page from '../components/Page';
 import Item from './Components/Item';
 import { ComponentDoc } from '../components/Doc';
@@ -46,7 +46,7 @@ export const NavItem = ({ name, path }) => (
   <Item name={name} path={path} center>
     <Nav direction="row" align="end" background="brand" pad="medium">
       <Anchor as="span" icon={<FacebookOption />} hoverIndicator />
-      <Anchor as="span" icon={<Twitter />} hoverIndicator />
+      <Anchor as="span" icon={<X />} hoverIndicator />
       <Anchor as="span" icon={<Github />} hoverIndicator />
       <Anchor as="span" icon={<Linkedin />} hoverIndicator />
     </Nav>


### PR DESCRIPTION
## What does this PR do?

### Updates all references of Twitter to X in the project.
- Replaces the old Twitter logo with the new X logo.
- Ensures consistency with the latest branding changes.

## Screenshot
![Screenshot 2025-03-03 223712](https://github.com/user-attachments/assets/34a45565-4a41-4b2e-a102-eb37cb9e131d)

## Why is this needed?

- Twitter has officially rebranded to X, so this update keeps the project up to date.

## Changes Made:

- Renamed "Twitter" to "X" across the website.
- Replaced the Twitter icon with the new X logo.

## How to Test:

- Run the project locally by `pnpm i` & `pnpm start`
- Check all instances where Twitter was mentioned (links, icons, text).
- Verify that they are now correctly updated to X.