### PR TITLE
update docs to reflect latest changes

### DIFF
--- a/src/screens/Calendar.js
+++ b/src/screens/Calendar.js
@@ -374,7 +374,7 @@ const CalendarPage = () => (
               An object with a color for dark and light modes.
             </Description>
             <Example defaultValue>
-              {`{ dark: "light-4", light: "dark-3" }`}
+              {`{ background: "active-background"}`}
             </Example>
           </PropertyValue>
         </Property>

--- a/src/screens/DataTable.js
+++ b/src/screens/DataTable.js
@@ -302,7 +302,8 @@ const DataTablePage = () => (
               to specify which items in the data are group header items and
               'select' and 'onSelect' can be specified in 'groupBy' to help
               specify the selection state of the groups and handle changes in
-              group selection state.
+              group selection state. ExpandLabel can be used to specify a
+              aria-label for the expand button.
             </Description>
             <Example>
               {`
@@ -310,6 +311,7 @@ const DataTablePage = () => (
   "property": "location",
   "expand": ["Paris", "Los Angeles"],
   "onExpand": "(key) => {...}"
+  "expandLabel": (row) => \`Show details for \${row.name}\`,
 }
             `}
             </Example>
@@ -318,6 +320,7 @@ const DataTablePage = () => (
 {
   "property": "location",
   "expand": ["Paris", "Los Angeles"],
+  "expandLabel": (row) => \`Show details for \${row.name}\`,
   "expandable": ["Paris", "Los Angeles", "Fort Collins", "San Jose"],
   "select": { "": "some", "Paris": "all", "Los Angeles": "some"}
   "onSelect": (selected, datum, groupBySelected) => {...}
@@ -354,7 +357,8 @@ const DataTablePage = () => (
             above), and can optionally include: expand: an array of row keys
             (strings or numbers) that are currently expanded. onExpand: a
             callback function called with the next expanded row keys when a user
-            expands or collapses a row.
+            expands or collapses a row. ExpandLabel can be used to specify a
+            aria-label for the expand button.
           </Description>
           <PropertyValue type="function">
             <Example>{`() => {}`}</Example>
@@ -363,6 +367,7 @@ const DataTablePage = () => (
             <Example>{`{
   render: (row) => <div>Details for {row.name}</div>,
   expand: [1, 3], // Row keys that are currently expanded
+  expandLabel: (row) => \`Show details for \${row.name}\`,
   onExpand: () => (),
 }`}</Example>
           </PropertyValue>

--- a/src/screens/FormField.js
+++ b/src/screens/FormField.js
@@ -122,7 +122,8 @@ const FormFieldPage = () => (
         <Property name="htmlFor">
           <Description>
             The id of the input element contained in this field. If the input
-            element is Select or SelectMultiple, append "__input" to the id.
+            element is Select or SelectMultiple, Grommet will automatically
+            append "__input" to the id of the input element.
           </Description>
           <PropertyValue type="string">
             <Example>"input-id"</Example>

--- a/src/screens/Grommet.js
+++ b/src/screens/Grommet.js
@@ -303,9 +303,28 @@ const GrommetPage = () => (
       total: "string",
       totalSingle: "string"
     },
+    dataTable: {
+      ascending: "string",
+      collapse: "string",
+      collapseAll: "string",
+      decrease: "string",
+      descending: "string",
+      expand: "string",
+      expandAll: "string",
+      resizerAria: "string",
+      rows: "string",
+      rowsChanged: "string",
+      rowsSingle: "string",
+      searchBy: "string",
+      total: "string",
+      totalSingle: "string"
+    },
     dataTableColumns: {
       open: "string",
       order: "string",
+      pinned: "string",
+      orderAria: "string",
+      selectAria: "string",
       select: "string",
       tip: "string"
     },
@@ -373,6 +392,9 @@ const GrommetPage = () => (
         singular: "string",
         plural: "string",
       },
+    },
+    notifications: {
+      close: "string",
     },
     pagination: {
       stepLabel: "string",

--- a/src/screens/RangeSelector.js
+++ b/src/screens/RangeSelector.js
@@ -272,6 +272,15 @@ const RangeSelectorPage = () => (
           </PropertyValue>
         </Property>
 
+        <Property name="rangeSelector.edge.size">
+          <Description>The edge control size.</Description>
+          <PropertyValue type="string">
+            <Example>"small"</Example>
+            <Example>"medium"</Example>
+            <Example>"large"</Example>
+          </PropertyValue>
+        </Property>
+
         <Property name="global.spacing">
           <Description>The size of the edge controls thumb.</Description>
           <PropertyValue type="string">

--- a/src/screens/Select.js
+++ b/src/screens/Select.js
@@ -632,9 +632,25 @@ const SelectPage = () => (
           <GenericExtend />
         </Property>
 
+        <Property name="select.clear.button">
+          <Description>
+            Any valid Button prop, for the clear button.
+          </Description>
+          <PropertyValue type="object">
+            <Example defaultValue>
+              {`{  
+            color: 'red',
+            border: {
+              radius: '10px',
+            },
+          }`}
+            </Example>
+          </PropertyValue>
+        </Property>
+
         <Property name="select.clear.container">
           <Description>
-            Any valid Box prop for the clear button container.
+            Any valid Box prop, for the clear button container.
           </Description>
           <PropertyValue type="object">
             <Example defaultValue>

--- a/src/utils/themeDocUtils.js
+++ b/src/utils/themeDocUtils.js
@@ -110,6 +110,28 @@ export const FocusStyle = () => (
         <Example>{`{ dark: "string", light: "string" }`}</Example>
       </PropertyValue>
     </Property>
+    <Property name="global.focus.inset">
+      <Description>
+        The inset of the border around the component when in focus.
+      </Description>
+      <PropertyValue type="object">
+        <Description>
+          An object can contain a border, outline, shadow, and twoColor.
+        </Description>
+        <Example>
+          {`{    
+        inset: {
+          border: {
+            color: 'focus',
+          },
+          outline: { color: 'focus', size: '2px', offset: '-2px' },
+          shadow: undefined,
+          twoColor: undefined,
+        },}`}
+        </Example>
+      </PropertyValue>
+    </Property>
+
     <Property name="global.focus.outline.color">
       <Description>
         The outline color around the component when in focus.


### PR DESCRIPTION
- changed the `default` background color to reflect the change we made https://github.com/grommet/grommet/pull/7612
- added `expandLabel` to docs
- re-word the FormField `htmlFor` to let the user know that grommet appends a __input
- add new `messages` for DataTable, DataTableColumns, and Notifications
- add `rangeSelector.edgesize` to docs 
- add `select.clear.button` to docs
- add `global.focus.inset` to docs