### PR TITLE
add docs for feb release

### DIFF
--- a/src/screens/DataChart.js
+++ b/src/screens/DataChart.js
@@ -517,8 +517,7 @@ const DataChartPage = () => (
       <ThemeDoc>
         <Property name="dataChart.colors">
           <Description>
-            Adds theme.dataChart.colors to enable specification of colors that
-            that should be used for DataChart via the theme.
+            Enables specification of colors used by the DataChart.
           </Description>
           <PropertyValue type="string[]">
             <Example>{`['brand', 'accent-1', 'accent-2', 'accent-3']`}</Example>

--- a/src/screens/DataChart.js
+++ b/src/screens/DataChart.js
@@ -18,6 +18,7 @@ import {
   Property,
   PropertyValue,
   Description,
+  ThemeDoc,
   Example,
   PropOptions,
 } from '../components/Doc';
@@ -513,6 +514,17 @@ const DataChartPage = () => (
           </PropertyValue>
         </Property>
       </Properties>
+      <ThemeDoc>
+        <Property name="dataChart.colors">
+          <Description>
+            Adds theme.dataChart.colors to enable specification of colors that
+            that should be used for DataChart via the theme.
+          </Description>
+          <PropertyValue type="string[]">
+            <Example>{`['brand', 'accent-1', 'accent-2', 'accent-3']`}</Example>
+          </PropertyValue>
+        </Property>
+      </ThemeDoc>
     </ComponentDoc>
   </Page>
 );

--- a/src/screens/DataTableColumns.js
+++ b/src/screens/DataTableColumns.js
@@ -32,8 +32,7 @@ const DataTableColumnsPage = () => (
       <Properties>
         <Property name="activePanel">
           <Description>
-            Added activePanel prop to DataTableColumns component to enable only
-            showing either the order columns or select columns panel.
+            Whether to show only the order columns or select columns panel.
           </Description>
           <PropertyValue type="string">
             <Example>"orderColumns"</Example>

--- a/src/screens/DataTableColumns.js
+++ b/src/screens/DataTableColumns.js
@@ -30,6 +30,17 @@ const DataTableColumnsPage = () => (
 </Data>`}
     >
       <Properties>
+        <Property name="activePanel">
+          <Description>
+            Added activePanel prop to DataTableColumns component to enable only
+            showing either the order columns or select columns panel.
+          </Description>
+          <PropertyValue type="string">
+            <Example>"orderColumns"</Example>
+            <Example>"selectColumns"</Example>
+          </PropertyValue>
+        </Property>
+
         <Property name="drop">
           <Description>
             Whether to show the controls via a DropButton.


### PR DESCRIPTION
Added the following:

- Added activePanel prop to DataTableColumns component to enable only showing either the order columns or select columns panel. (https://github.com/grommet/grommet/pull/7703)
- Added theme.dataChart.colors to enable theme-based color specification for DataChart components. (https://github.com/grommet/grommet/pull/7864)