### PR TITLE
add a script for grommet docs to run to update the docs

### DIFF
--- a/.github/workflows/grommet-doc-drift.yml
+++ b/.github/workflows/grommet-doc-drift.yml
@@ -37,7 +37,8 @@ jobs:
         id: drift
         run: |
           node tools/check-grommet-doc-drift.js --write
-          echo "has_drift=$(node -p "require('./tools/.grommet-drift-summary.json').hasDrift")" >> "$GITHUB_OUTPUT"
+          HAS_DRIFT=$(node -p "require('./tools/.grommet-drift-summary.json').hasDrift")
+          echo "has_drift=$HAS_DRIFT" >> "$GITHUB_OUTPUT"
 
       - name: Create pull request
         if: steps.drift.outputs.has_drift == 'true'

--- a/.github/workflows/grommet-doc-drift.yml
+++ b/.github/workflows/grommet-doc-drift.yml
@@ -1,0 +1,57 @@
+name: Grommet doc drift check
+
+# Periodically pulls the latest `grommet` (stable branch) and checks whether
+# any components/props exist there that aren't documented on grommet-site
+# yet. If so, it scaffolds stub documentation and opens a draft PR for a
+# maintainer to review, describe, and merge.
+
+on:
+  schedule:
+    # Every Monday at 13:00 UTC.
+    - cron: '0 13 * * 1'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: yarn install --ignore-engines
+
+      - name: Fetch latest grommet (stable)
+        run: yarn upgrade grommet --ignore-engines
+
+      - name: Run drift check
+        id: drift
+        run: |
+          node tools/check-grommet-doc-drift.js --write
+          echo "has_drift=$(node -p "require('./tools/.grommet-drift-summary.json').hasDrift")" >> "$GITHUB_OUTPUT"
+
+      - name: Create pull request
+        if: steps.drift.outputs.has_drift == 'true'
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          commit-message: 'chore: scaffold docs for new grommet components/props'
+          branch: grommet-doc-sync
+          delete-branch: true
+          draft: true
+          title: 'Grommet doc sync: new components/props detected'
+          body-path: tools/.grommet-drift-report.md
+          add-paths: |
+            src/screens/**
+            src/structure.js
+            src/components/Content.js
+            package.json
+            yarn.lock

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ npm-debug.log
 yarn-error.log
 .DS_Store
 package-lock.json
+tools/.grommet-drift-report.md
+tools/.grommet-drift-summary.json

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "build-static": "yarn build && yarn build-pages",
     "lint": "eslint src",
     "lint-fix": "eslint src --fix",
+    "check-grommet-doc-drift": "node tools/check-grommet-doc-drift.js",
     "test": "eslint src",
     "prettier": "pretty-quick --staged",
     "server": "http-server dist"

--- a/tools/check-grommet-doc-drift.js
+++ b/tools/check-grommet-doc-drift.js
@@ -22,6 +22,8 @@ const GROMMET_COMPONENTS_DIR = path.join(
 const SCREENS_DIR = path.join(ROOT, 'src/screens');
 const STRUCTURE_FILE = path.join(ROOT, 'src/structure.js');
 const CONTENT_FILE = path.join(ROOT, 'src/components/Content.js');
+const COMPONENT_ITEMS_FILE = path.join(ROOT, 'src/screens/Components/items.js');
+const COMPONENT_INDEX_FILE = path.join(ROOT, 'src/screens/Components/index.js');
 const REPORT_JSON = path.join(ROOT, 'tools/.grommet-drift-summary.json');
 const REPORT_MD = path.join(ROOT, 'tools/.grommet-drift-report.md');
 
@@ -39,6 +41,7 @@ const SUB_COMPONENTS = new Set([
   'FocusedContainer',
   'NameValuePair',
   'PageContent',
+  'SkeletonItem',
   'SkipLink',
   'SkipLinkTarget',
   'Tab',
@@ -131,17 +134,27 @@ function getGrommetPropNames(componentName) {
     );
   };
 
-  // The local (non-exported) variable populated inside the
-  // `if (process.env.NODE_ENV !== 'production')` guard is named either
-  // `${componentName}PropType` (e.g. `CarouselPropType`) or, in many
-  // components, just the generic `PropType`. It's declared once (usually
-  // as an empty placeholder, e.g. `var PropType = {};`) and then reassigned
-  // with the real value inside the guard, so we want the LAST assignment,
-  // which is either a plain object literal or a merge via
-  // `_extends({}, sharedProps, { ...own })`.
-  const escaped = componentName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  // The local variable populated inside the
+  // `if (process.env.NODE_ENV !== 'production')` guard is commonly named
+  // `${componentName}PropType` (e.g. `CarouselPropType`) or `PropType`.
+  // Newer components can also export `${componentName}PropTypes` from a
+  // differently named local variable, e.g. `export const WizardPropTypes = propType;`.
+  // Collect all likely assignment targets and take the LAST assignment.
+  const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const candidateNames = new Set([`${componentName}PropType`, 'PropType']);
+  const propTypesAliasRe = new RegExp(
+    `(?:exports\\.${componentName}PropTypes\\s*=|export\\s+const\\s+${componentName}PropTypes\\s*=)\\s*([A-Za-z_$][A-Za-z0-9_$]*)`,
+    'g',
+  );
+  let aliasMatch = propTypesAliasRe.exec(source);
+  while (aliasMatch) {
+    candidateNames.add(aliasMatch[1]);
+    aliasMatch = propTypesAliasRe.exec(source);
+  }
   const assignRe = new RegExp(
-    `(?:${escaped}PropType|(?<![A-Za-z0-9_])PropType) = `,
+    `(?:^|[^A-Za-z0-9_$])(?:${[...candidateNames]
+      .map(escapeRegExp)
+      .join('|')})\\s*=`,
     'g',
   );
   let match;
@@ -238,7 +251,7 @@ function guessPropertyValue(valueSrc) {
     return { type: 'number', examples: ['0'] };
   }
   if (/\.node\b/.test(valueSrc)) {
-    return { type: 'node | element', examples: ['<Box />'] };
+    return { type: 'node | element', examples: ['TODO: add example'] };
   }
   if (/\.(shape|object)\b/.test(valueSrc)) {
     return { type: 'object', examples: ['{}'] };
@@ -249,10 +262,22 @@ function guessPropertyValue(valueSrc) {
   return { type: 'string', examples: ['"TODO"'] };
 }
 
+function escapeTemplateLiteral(value) {
+  return String(value).replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
+}
+
 function buildPropertyStub(propName, valueSrc) {
   const { type, examples } = guessPropertyValue(valueSrc);
   const exampleLines = examples
-    .map((example) => `            <Example>${example}</Example>`)
+    .map((example) => {
+      const value = String(example);
+      if (/[<>{}]/.test(value)) {
+        return `            <Example>{\`${escapeTemplateLiteral(
+          value,
+        )}\`}</Example>`;
+      }
+      return `            <Example>${value}</Example>`;
+    })
     .join('\n');
   return `        <Property name="${propName}">
           {/* TODO: auto-generated stub, please review */}
@@ -270,7 +295,8 @@ function insertPropsIntoScreen(componentName, missingProps) {
   if (closeIndex === -1) return false;
   const before = content.slice(0, closeIndex).replace(/\s+$/, '');
   const after = content.slice(closeIndex);
-  const stubs = missingProps
+  const stubs = [...missingProps]
+    .sort((a, b) => a.name.localeCompare(b.name))
     .map(({ name, value }) => buildPropertyStub(name, value))
     .join('\n\n');
   fs.writeFileSync(file, `${before}\n\n${stubs}\n\n      ${after}`);
@@ -278,12 +304,14 @@ function insertPropsIntoScreen(componentName, missingProps) {
 }
 
 function buildSkeletonScreen(componentName, props) {
-  const propertyStubs = props
+  const propertyStubs = [...props]
+    .sort((a, b) => a.name.localeCompare(b.name))
     .map(({ name, value }) => buildPropertyStub(name, value))
     .join('\n\n');
   return `import React from 'react';
-import { ${componentName} } from 'grommet';
+import { Box, Text } from 'grommet';
 import Page from '../components/Page';
+import Item from './Components/Item';
 import {
   ComponentDoc,
   Properties,
@@ -308,7 +336,7 @@ const ${componentName}Page = () => (
         },
       ]}
       description="TODO: describe ${componentName}"
-      code={\`<${componentName} />\`}
+      code="TODO: add ${componentName} code"
     >
       <Properties>
 ${propertyStubs}
@@ -318,6 +346,16 @@ ${propertyStubs}
 );
 
 export default ${componentName}Page;
+
+export const ${componentName}Item = ({ name, path }) => (
+  <Item name={name} path={path} center>
+    <Box pad="medium" align="center">
+      <Text size="small">TODO: add ${componentName} item</Text>
+    </Box>
+  </Item>
+);
+
+${componentName}Item.propTypes = Item.propTypes;
 `;
 }
 
@@ -377,6 +415,64 @@ function addComponentToContent(componentName) {
   fs.writeFileSync(CONTENT_FILE, updated);
 }
 
+function addComponentToItems(componentName) {
+  const content = fs.readFileSync(COMPONENT_ITEMS_FILE, 'utf8');
+  const exportLine = `export { ${componentName}Item } from '../${componentName}';\n`;
+  if (content.includes(exportLine)) return;
+  const lines = content.split('\n').filter(Boolean);
+  lines.push(exportLine.trimEnd());
+  lines.sort((a, b) => a.localeCompare(b));
+  fs.writeFileSync(COMPONENT_ITEMS_FILE, `${lines.join('\n')}\n`);
+}
+
+function addComponentToComponentsIndex(componentName) {
+  const content = fs.readFileSync(COMPONENT_INDEX_FILE, 'utf8');
+  const importMarker = "} from './items';";
+  const importLine = `  ${componentName}Item,\n`;
+  let updated = content;
+  if (!content.includes(importLine)) {
+    const importStart = content.indexOf('import {\n');
+    const importEnd = content.indexOf(importMarker, importStart);
+    const importBlock = content.slice(importStart, importEnd);
+    const importEntries = importBlock
+      .split('\n')
+      .slice(1)
+      .filter((line) => line.trim())
+      .map((line) => line.trim().replace(/,$/, ''));
+    importEntries.push(`${componentName}Item`);
+    importEntries.sort((a, b) => a.localeCompare(b));
+    const rebuiltImport = `import {\n${importEntries
+      .map((entry) => `  ${entry},`)
+      .join('\n')}\n${importMarker}`;
+    updated =
+      content.slice(0, importStart) +
+      rebuiltImport +
+      content.slice(importEnd + importMarker.length);
+  }
+
+  const itemsBlockMarker = 'const Items = {';
+  const itemsStart = updated.indexOf(itemsBlockMarker);
+  const itemsEnd = updated.indexOf('\n};', itemsStart);
+  const itemsBlock = updated.slice(itemsStart, itemsEnd);
+  const itemLine = `  ${componentName}: ${componentName}Item,`;
+  if (!itemsBlock.includes(itemLine)) {
+    const existingLines = itemsBlock
+      .split('\n')
+      .slice(1)
+      .filter((line) => line.trim())
+      .map((line) => line.trim().replace(/,$/, ''));
+    existingLines.push(`${componentName}: ${componentName}Item`);
+    existingLines.sort((a, b) => a.localeCompare(b));
+    const rebuiltItems = `const Items = {\n${existingLines
+      .map((entry) => `  ${entry},`)
+      .join('\n')}`;
+    updated =
+      updated.slice(0, itemsStart) + rebuiltItems + updated.slice(itemsEnd);
+  }
+
+  fs.writeFileSync(COMPONENT_INDEX_FILE, updated);
+}
+
 function main() {
   const grommetComponents = getGrommetComponentNames().filter(
     (name) => !SUB_COMPONENTS.has(name),
@@ -409,6 +505,8 @@ function main() {
       fs.writeFileSync(file, buildSkeletonScreen(name, props));
       addComponentToStructure(name);
       addComponentToContent(name);
+      addComponentToItems(name);
+      addComponentToComponentsIndex(name);
     });
     Object.entries(updatedProps).forEach(([name, missing]) => {
       insertPropsIntoScreen(name, missing);

--- a/tools/check-grommet-doc-drift.js
+++ b/tools/check-grommet-doc-drift.js
@@ -64,7 +64,7 @@ function isDocumented(name) {
   return fs.existsSync(path.join(SCREENS_DIR, `${name}.js`));
 }
 
-// Returns the index just after the closing bracket matching the bracket at
+// Returns the index of the closing bracket matching the bracket at
 // `openIndex` (which must be '{', '(' or '[').
 function findMatchingBracket(source, openIndex) {
   const openChar = source[openIndex];

--- a/tools/check-grommet-doc-drift.js
+++ b/tools/check-grommet-doc-drift.js
@@ -277,7 +277,7 @@ const ${componentName}Page = () => (
       availableAt={[
         {
           url: 'https://github.com/grommet/grommet/tree/master/src/js/components/${componentName}',
-          label: 'Github',
+          label: 'GitHub',
         },
       ]}
       description="TODO: describe ${componentName}"

--- a/tools/check-grommet-doc-drift.js
+++ b/tools/check-grommet-doc-drift.js
@@ -395,7 +395,7 @@ function addComponentToContent(componentName) {
   const content = fs.readFileSync(CONTENT_FILE, 'utf8');
   const importLine = `import ${componentName} from '../screens/${componentName}';\n`;
   const lastImportMatch = [
-    ...content.matchAll(/^import .*from '\.\.\/screens\/.*';\n/gm),
+    ...content.matchAll(/^import .*from '\.\.\/screens\/[^/']+';\n/gm),
   ].pop();
   const importInsertAt = lastImportMatch
     ? lastImportMatch.index + lastImportMatch[0].length

--- a/tools/check-grommet-doc-drift.js
+++ b/tools/check-grommet-doc-drift.js
@@ -124,6 +124,13 @@ function getGrommetPropNames(componentName) {
   const file = path.join(GROMMET_COMPONENTS_DIR, componentName, 'propTypes.js');
   const source = fs.readFileSync(file, 'utf8');
 
+  const warnParseFailure = (reason) => {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `Warning: could not parse propTypes for \`${componentName}\` (${reason}). Skipping drift check for this component.`,
+    );
+  };
+
   // The local (non-exported) variable populated inside the
   // `if (process.env.NODE_ENV !== 'production')` guard is named either
   // `${componentName}PropType` (e.g. `CarouselPropType`) or, in many
@@ -143,22 +150,42 @@ function getGrommetPropNames(componentName) {
   while ((match = assignRe.exec(source))) lastMatch = match;
   if (!lastMatch) return [];
   let i = lastMatch.index + lastMatch[0].length;
-  while (/\s/.test(source[i])) i += 1;
+  while (i < source.length && /\s/.test(source[i])) i += 1;
+  if (i >= source.length) {
+    warnParseFailure('unexpected end of file after PropType assignment');
+    return null;
+  }
 
   const entries = [];
   if (source[i] === '{') {
     const close = findMatchingBracket(source, i);
+    if (close === -1) {
+      warnParseFailure('unbalanced braces in PropType object literal');
+      return null;
+    }
     entries.push(...splitTopLevelEntries(source.slice(i + 1, close)));
   } else {
     // Merge-style assignment: pull entries out of every object literal
     // passed as an argument (shared prop bags referenced by identifier,
     // e.g. `_generalPropTypes.genericProps`, are not expanded here).
     const parenStart = source.indexOf('(', i);
+    if (parenStart === -1) {
+      warnParseFailure('expected "(" after PropType assignment');
+      return null;
+    }
     const parenEnd = findMatchingBracket(source, parenStart);
+    if (parenEnd === -1) {
+      warnParseFailure('unbalanced parentheses in PropType merge call');
+      return null;
+    }
     let j = parenStart + 1;
     while (j < parenEnd) {
       if (source[j] === '{') {
         const close = findMatchingBracket(source, j);
+        if (close === -1) {
+          warnParseFailure('unbalanced braces inside PropType merge call');
+          return null;
+        }
         entries.push(...splitTopLevelEntries(source.slice(j + 1, close)));
         j = close + 1;
       } else {
@@ -357,9 +384,16 @@ function main() {
 
   const newComponents = [];
   const updatedProps = {};
+  const unparseableComponents = [];
 
   grommetComponents.forEach((name) => {
     const props = getGrommetPropNames(name);
+    if (props === null) {
+      // propTypes.js couldn't be parsed safely (unbalanced brackets/unknown
+      // syntax); skip this component rather than risk acting on bad data.
+      unparseableComponents.push(name);
+      return;
+    }
     if (!isDocumented(name)) {
       newComponents.push({ name, props });
       return;
@@ -393,6 +427,7 @@ function main() {
         props.map((p) => p.name),
       ]),
     ),
+    unparseableComponents,
   };
 
   const reportLines = ['# Grommet documentation drift report', ''];
@@ -419,6 +454,19 @@ function main() {
       WRITE
         ? '_Skeleton files/stubs were generated. Please review descriptions and examples before merging._'
         : '_Run with --write to generate skeleton files/stubs._',
+    );
+  }
+
+  if (unparseableComponents.length) {
+    reportLines.push(
+      '',
+      '## Components skipped due to parse errors',
+      '',
+      "_These components' `propTypes.js` couldn't be parsed safely and were" +
+        ' not checked for drift. Please review manually. See the workflow' +
+        ' logs for details._',
+      '',
+      ...unparseableComponents.map((name) => `- \`${name}\``),
     );
   }
 

--- a/tools/check-grommet-doc-drift.js
+++ b/tools/check-grommet-doc-drift.js
@@ -1,0 +1,434 @@
+/**
+ * Detects components and props that exist in the installed `grommet`
+ * package but are not yet documented on grommet-site, and (with --write)
+ * scaffolds stub documentation for them so a human only has to fill in
+ * descriptions/examples instead of authoring the whole page from scratch.
+ *
+ * Usage:
+ *   node tools/check-grommet-doc-drift.js            # report only
+ *   node tools/check-grommet-doc-drift.js --write     # also write skeleton files
+ *
+ * This script is intentionally dependency-free (plain CommonJS + fs/path)
+ * so it can run in CI without babel-node.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const GROMMET_COMPONENTS_DIR = path.join(
+  ROOT,
+  'node_modules/grommet/components',
+);
+const SCREENS_DIR = path.join(ROOT, 'src/screens');
+const STRUCTURE_FILE = path.join(ROOT, 'src/structure.js');
+const CONTENT_FILE = path.join(ROOT, 'src/components/Content.js');
+const REPORT_JSON = path.join(ROOT, 'tools/.grommet-drift-summary.json');
+const REPORT_MD = path.join(ROOT, 'tools/.grommet-drift-report.md');
+
+const WRITE = process.argv.includes('--write');
+
+// grommet folders that are documented as part of a parent component's page
+// (e.g. Card's Body/Footer/Header), not as their own top-level screen.
+// Update this list if grommet intentionally ships a new sub-component
+// pattern that should never get its own page.
+const SUB_COMPONENTS = new Set([
+  'AccordionPanel',
+  'CardBody',
+  'CardFooter',
+  'CardHeader',
+  'FocusedContainer',
+  'NameValuePair',
+  'PageContent',
+  'SkipLink',
+  'SkipLinkTarget',
+  'Tab',
+  'TableBody',
+  'TableCell',
+  'TableFooter',
+  'TableHeader',
+  'TableRow',
+]);
+
+function getGrommetComponentNames() {
+  return fs
+    .readdirSync(GROMMET_COMPONENTS_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) =>
+      fs.existsSync(path.join(GROMMET_COMPONENTS_DIR, name, 'propTypes.js')),
+    )
+    .sort();
+}
+
+function isDocumented(name) {
+  return fs.existsSync(path.join(SCREENS_DIR, `${name}.js`));
+}
+
+// Returns the index just after the closing bracket matching the bracket at
+// `openIndex` (which must be '{', '(' or '[').
+function findMatchingBracket(source, openIndex) {
+  const openChar = source[openIndex];
+  const closeChar = { '{': '}', '(': ')', '[': ']' }[openChar];
+  let depth = 0;
+  for (let i = openIndex; i < source.length; i += 1) {
+    if (source[i] === openChar) depth += 1;
+    else if (source[i] === closeChar) {
+      depth -= 1;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+// Splits an object literal body into top-level `key: value` entries,
+// respecting nested {}, [], (), and quoted strings.
+function splitTopLevelEntries(body) {
+  const entries = [];
+  let depth = 0;
+  let quote = null;
+  let start = 0;
+  for (let i = 0; i < body.length; i += 1) {
+    const ch = body[i];
+    if (quote) {
+      if (ch === '\\') i += 1;
+      else if (ch === quote) quote = null;
+    } else if (ch === '"' || ch === "'" || ch === '`') {
+      quote = ch;
+    } else if (ch === '{' || ch === '[' || ch === '(') {
+      depth += 1;
+    } else if (ch === '}' || ch === ']' || ch === ')') {
+      depth -= 1;
+    } else if (ch === ',' && depth === 0) {
+      entries.push(body.slice(start, i));
+      start = i + 1;
+    }
+  }
+  const last = body.slice(start);
+  if (last.trim()) entries.push(last);
+
+  return entries
+    .map((entry) => {
+      const colonIndex = entry.indexOf(':');
+      if (colonIndex === -1) return null;
+      const name = entry
+        .slice(0, colonIndex)
+        .trim()
+        .replace(/^["']|["']$/g, '');
+      const value = entry.slice(colonIndex + 1).trim();
+      return name ? { name, value } : null;
+    })
+    .filter(Boolean);
+}
+
+function getGrommetPropNames(componentName) {
+  const file = path.join(GROMMET_COMPONENTS_DIR, componentName, 'propTypes.js');
+  const source = fs.readFileSync(file, 'utf8');
+
+  // The local (non-exported) variable populated inside the
+  // `if (process.env.NODE_ENV !== 'production')` guard is named either
+  // `${componentName}PropType` (e.g. `CarouselPropType`) or, in many
+  // components, just the generic `PropType`. It's declared once (usually
+  // as an empty placeholder, e.g. `var PropType = {};`) and then reassigned
+  // with the real value inside the guard, so we want the LAST assignment,
+  // which is either a plain object literal or a merge via
+  // `_extends({}, sharedProps, { ...own })`.
+  const escaped = componentName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const assignRe = new RegExp(
+    `(?:${escaped}PropType|(?<![A-Za-z0-9_])PropType) = `,
+    'g',
+  );
+  let match;
+  let lastMatch;
+  // eslint-disable-next-line no-cond-assign
+  while ((match = assignRe.exec(source))) lastMatch = match;
+  if (!lastMatch) return [];
+  let i = lastMatch.index + lastMatch[0].length;
+  while (/\s/.test(source[i])) i += 1;
+
+  const entries = [];
+  if (source[i] === '{') {
+    const close = findMatchingBracket(source, i);
+    entries.push(...splitTopLevelEntries(source.slice(i + 1, close)));
+  } else {
+    // Merge-style assignment: pull entries out of every object literal
+    // passed as an argument (shared prop bags referenced by identifier,
+    // e.g. `_generalPropTypes.genericProps`, are not expanded here).
+    const parenStart = source.indexOf('(', i);
+    const parenEnd = findMatchingBracket(source, parenStart);
+    let j = parenStart + 1;
+    while (j < parenEnd) {
+      if (source[j] === '{') {
+        const close = findMatchingBracket(source, j);
+        entries.push(...splitTopLevelEntries(source.slice(j + 1, close)));
+        j = close + 1;
+      } else {
+        j += 1;
+      }
+    }
+  }
+
+  // De-dupe by name (later entries win, matching object spread semantics).
+  const byName = new Map();
+  entries.forEach((entry) => byName.set(entry.name, entry));
+  return [...byName.values()];
+}
+
+function getDocumentedPropNames(componentName) {
+  const file = path.join(SCREENS_DIR, `${componentName}.js`);
+  const content = fs.readFileSync(file, 'utf8');
+  const names = new Set();
+  const re = /<Property\s+name="([^"]+)"/g;
+  let match = re.exec(content);
+  while (match) {
+    names.add(match[1]);
+    match = re.exec(content);
+  }
+  return names;
+}
+
+// Best-effort guess of a PropertyValue "type" + placeholder example from
+// the raw prop-types validator source, e.g. `_propTypes["default"].bool`
+// or `_propTypes["default"].oneOf(['12', '24'])`.
+function guessPropertyValue(valueSrc) {
+  const oneOfMatch = valueSrc.match(/\.oneOf\(\[([\s\S]*?)\]\)/);
+  if (oneOfMatch) {
+    const options = oneOfMatch[1]
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    return {
+      type: 'string',
+      examples: options.length ? options : ['"TODO"'],
+    };
+  }
+  if (/\.bool\b/.test(valueSrc)) {
+    return { type: 'boolean', examples: ['true', 'false'] };
+  }
+  if (/\.func\b/.test(valueSrc)) {
+    return { type: 'function', examples: ['() => {}'] };
+  }
+  if (/\.number\b/.test(valueSrc)) {
+    return { type: 'number', examples: ['0'] };
+  }
+  if (/\.node\b/.test(valueSrc)) {
+    return { type: 'node | element', examples: ['<Box />'] };
+  }
+  if (/\.(shape|object)\b/.test(valueSrc)) {
+    return { type: 'object', examples: ['{}'] };
+  }
+  if (/\.(arrayOf|array)\b/.test(valueSrc)) {
+    return { type: 'array', examples: ['[]'] };
+  }
+  return { type: 'string', examples: ['"TODO"'] };
+}
+
+function buildPropertyStub(propName, valueSrc) {
+  const { type, examples } = guessPropertyValue(valueSrc);
+  const exampleLines = examples
+    .map((example) => `            <Example>${example}</Example>`)
+    .join('\n');
+  return `        <Property name="${propName}">
+          {/* TODO: auto-generated stub, please review */}
+          <Description>TODO: describe ${propName}.</Description>
+          <PropertyValue type="${type}">
+${exampleLines}
+          </PropertyValue>
+        </Property>`;
+}
+
+function insertPropsIntoScreen(componentName, missingProps) {
+  const file = path.join(SCREENS_DIR, `${componentName}.js`);
+  const content = fs.readFileSync(file, 'utf8');
+  const closeIndex = content.indexOf('</Properties>');
+  if (closeIndex === -1) return false;
+  const before = content.slice(0, closeIndex).replace(/\s+$/, '');
+  const after = content.slice(closeIndex);
+  const stubs = missingProps
+    .map(({ name, value }) => buildPropertyStub(name, value))
+    .join('\n\n');
+  fs.writeFileSync(file, `${before}\n\n${stubs}\n\n      ${after}`);
+  return true;
+}
+
+function buildSkeletonScreen(componentName, props) {
+  const propertyStubs = props
+    .map(({ name, value }) => buildPropertyStub(name, value))
+    .join('\n\n');
+  return `import React from 'react';
+import { ${componentName} } from 'grommet';
+import Page from '../components/Page';
+import {
+  ComponentDoc,
+  Properties,
+  Property,
+  PropertyValue,
+  Description,
+  Example,
+} from '../components/Doc';
+
+// TODO: auto-generated by tools/check-grommet-doc-drift.js because
+// \`${componentName}\` was found in the installed grommet package with no
+// matching documentation on grommet-site. Please review the description,
+// code example, and every prop below before merging.
+const ${componentName}Page = () => (
+  <Page>
+    <ComponentDoc
+      name="${componentName}"
+      availableAt={[
+        {
+          url: 'https://github.com/grommet/grommet/tree/master/src/js/components/${componentName}',
+          label: 'Github',
+        },
+      ]}
+      description="TODO: describe ${componentName}"
+      code={\`<${componentName} />\`}
+    >
+      <Properties>
+${propertyStubs}
+      </Properties>
+    </ComponentDoc>
+  </Page>
+);
+
+export default ${componentName}Page;
+`;
+}
+
+function addComponentToStructure(componentName) {
+  const content = fs.readFileSync(STRUCTURE_FILE, 'utf8');
+  const sectionMarker = "name: 'Needs Review'";
+  if (content.includes(sectionMarker)) {
+    const sectionIndex = content.indexOf(sectionMarker);
+    const componentsIndex = content.indexOf('components: [', sectionIndex);
+    const insertAt = componentsIndex + 'components: ['.length;
+    const updated = `${content.slice(
+      0,
+      insertAt,
+    )}\n        '${componentName}',${content.slice(insertAt)}`;
+    fs.writeFileSync(STRUCTURE_FILE, updated);
+    return;
+  }
+  // Create a "Needs Review" section right before the closing `],\n};` of
+  // `structure.sections`.
+  const closeMarker = '\n  ],\n};';
+  const closeIndex = content.lastIndexOf(closeMarker);
+  const newSection = `    {
+      name: 'Needs Review',
+      components: [
+        '${componentName}',
+      ],
+    },
+`;
+  const updated =
+    content.slice(0, closeIndex + 1) +
+    newSection +
+    content.slice(closeIndex + 1);
+  fs.writeFileSync(STRUCTURE_FILE, updated);
+}
+
+function addComponentToContent(componentName) {
+  const content = fs.readFileSync(CONTENT_FILE, 'utf8');
+  const importLine = `import ${componentName} from '../screens/${componentName}';\n`;
+  const lastImportMatch = [
+    ...content.matchAll(/^import .*from '\.\.\/screens\/.*';\n/gm),
+  ].pop();
+  const importInsertAt = lastImportMatch
+    ? lastImportMatch.index + lastImportMatch[0].length
+    : content.indexOf('\n') + 1;
+  let updated =
+    content.slice(0, importInsertAt) +
+    importLine +
+    content.slice(importInsertAt);
+
+  const routeLine = `    <Route exact path="/${componentName.toLowerCase()}" component={${componentName}} />\n`;
+  const routesCloseIndex = updated.lastIndexOf('  </Routes>');
+  updated =
+    updated.slice(0, routesCloseIndex) +
+    routeLine +
+    updated.slice(routesCloseIndex);
+
+  fs.writeFileSync(CONTENT_FILE, updated);
+}
+
+function main() {
+  const grommetComponents = getGrommetComponentNames().filter(
+    (name) => !SUB_COMPONENTS.has(name),
+  );
+
+  const newComponents = [];
+  const updatedProps = {};
+
+  grommetComponents.forEach((name) => {
+    const props = getGrommetPropNames(name);
+    if (!isDocumented(name)) {
+      newComponents.push({ name, props });
+      return;
+    }
+    const documented = getDocumentedPropNames(name);
+    const missing = props.filter((p) => !documented.has(p.name));
+    if (missing.length) updatedProps[name] = missing;
+  });
+
+  if (WRITE) {
+    newComponents.forEach(({ name, props }) => {
+      const file = path.join(SCREENS_DIR, `${name}.js`);
+      fs.writeFileSync(file, buildSkeletonScreen(name, props));
+      addComponentToStructure(name);
+      addComponentToContent(name);
+    });
+    Object.entries(updatedProps).forEach(([name, missing]) => {
+      insertPropsIntoScreen(name, missing);
+    });
+  }
+
+  const hasDrift =
+    newComponents.length > 0 || Object.keys(updatedProps).length > 0;
+
+  const summary = {
+    hasDrift,
+    newComponents: newComponents.map((c) => c.name),
+    updatedProps: Object.fromEntries(
+      Object.entries(updatedProps).map(([name, props]) => [
+        name,
+        props.map((p) => p.name),
+      ]),
+    ),
+  };
+
+  const reportLines = ['# Grommet documentation drift report', ''];
+  if (!hasDrift) {
+    reportLines.push(
+      'No drift detected between grommet and grommet-site docs.',
+    );
+  } else {
+    if (newComponents.length) {
+      reportLines.push('## New components missing documentation', '');
+      newComponents.forEach(({ name }) => reportLines.push(`- \`${name}\``));
+      reportLines.push('');
+    }
+    if (Object.keys(updatedProps).length) {
+      reportLines.push('## Existing components with undocumented props', '');
+      Object.entries(updatedProps).forEach(([name, props]) => {
+        reportLines.push(
+          `- \`${name}\`: ${props.map((p) => `\`${p.name}\``).join(', ')}`,
+        );
+      });
+      reportLines.push('');
+    }
+    reportLines.push(
+      WRITE
+        ? '_Skeleton files/stubs were generated. Please review descriptions and examples before merging._'
+        : '_Run with --write to generate skeleton files/stubs._',
+    );
+  }
+
+  fs.mkdirSync(path.dirname(REPORT_JSON), { recursive: true });
+  fs.writeFileSync(REPORT_JSON, JSON.stringify(summary, null, 2));
+  fs.writeFileSync(REPORT_MD, reportLines.join('\n'));
+
+  // eslint-disable-next-line no-console
+  console.log(reportLines.join('\n'));
+  process.exitCode = 0;
+}
+
+main();


### PR DESCRIPTION
## Automate detection of new grommet components/props missing from the docs site

### Why
Recently had to manually notice and add docs for `childrenPlain`, `TimeInput`, and `Stepper` after they landed in `grommet`. There was no way to know that documentation gaps existed except by memory. This adds automated drift detection so the site notices new components/props the same week they merge upstream, instead of relying on someone remembering to check.

### What's included

- **`tools/check-grommet-doc-drift.js`** — a Node script that:
  - Reads every component's `propTypes.js` shipped in the installed `grommet` package.
  - Compares prop names against the `<Property name="...">` blocks already authored in `src/screens/*.js`.
  - Flags **new grommet components with no screen file** and **existing components with undocumented props**.
  - With `--write`, scaffolds stub documentation: generates a skeleton `src/screens/<Name>.js` for new components (registering it in `src/structure.js` and `src/components/Content.js`), and inserts `<Property>` stubs (best-guess type/example + `TODO` description) for missing props on existing screens.
  - Without `--write`, just reports drift (safe to run locally/read-only).
  - Run via `yarn check-grommet-doc-drift`.

- **`.github/workflows/grommet-doc-drift.yml`** — scheduled GitHub Action (weekly, plus manual `workflow_dispatch`) that bumps `grommet` to the latest `stable` tarball, runs the script with `--write`, and opens a **draft PR** via `peter-evans/create-pull-request` (pinned to commit SHA for [`v8.1.1`](https://github.com/peter-evans/create-pull-request/releases/tag/v8.1.1)) when drift is found.

- Minor: `.gitignore` excludes the script's transient report artifacts (`tools/.grommet-drift-report.md`, `tools/.grommet-drift-summary.json`).

### What this does *not* automate
Grommet doesn't publish human-readable prop descriptions or usage examples anywhere machine-readable, so the bot can only scaffold structure (prop names, guessed types, route wiring) — real descriptions and examples still need a maintainer's review before merging the generated PR.

### Follow-ups / things to decide before relying on this
- If required CI checks should run automatically on the bot's PR, the default `GITHUB_TOKEN` won't trigger them (GitHub's anti-recursion rule) — would need a PAT or GitHub App token instead.
- Confirm branch protection allows the bot to push `grommet-doc-sync` and open PRs.
- The `SUB_COMPONENTS` allow-list in the script (e.g. `CardBody`, `TableRow`) may need updates if grommet introduces new sub-component patterns that shouldn't get their own top-level page.