### PR TITLE
Add beta flag that won't display the stable branch link

### DIFF
--- a/src/components/Doc/ComponentDoc.js
+++ b/src/components/Doc/ComponentDoc.js
@@ -20,6 +20,7 @@ export const ComponentDoc = ({
   pageTitle,
   designSystemLink,
   stable,
+  beta,
 }) => {
   const properties = [];
   const themeDoc = [];
@@ -50,19 +51,25 @@ export const ComponentDoc = ({
         <title>{pageTitle || name}</title>
         <meta name="description" content={description} />
       </Helmet>
-      {stable && (
+      {(beta || stable) && (
         <Box pad={{ bottom: 'medium' }}>
           <Notification
             background="light-3"
             status="info"
-            actions={[
-              {
-                label: 'stable branch.',
-                href: '/stablebranch',
-                target: '_blank',
-              },
-            ]}
-            message={`New! ${name} is in beta, the API is subject to change. Feel free to test it out and let us know what you think! This component is available on the`}
+            actions={
+              stable
+                ? [
+                    {
+                      label: 'stable branch.',
+                      href: '/stablebranch',
+                      target: '_blank',
+                    },
+                  ]
+                : []
+            }
+            message={`New! ${name} is in beta, the API is subject to change. Feel free to test it out and let us know what you think! ${
+              stable ? 'This component is available on the' : ''
+            } `}
           />
         </Box>
       )}
@@ -180,6 +187,7 @@ ComponentDoc.propTypes = {
   pageTitle: PropTypes.string,
   designSystemLink: PropTypes.string,
   stable: PropTypes.bool,
+  beta: PropTypes.bool,
 };
 
 ComponentDoc.defaultProps = {
@@ -193,4 +201,5 @@ ComponentDoc.defaultProps = {
   pageTitle: undefined,
   designSystemLink: undefined,
   stable: false,
+  beta: false,
 };

--- a/src/screens/DateTimeInput.js
+++ b/src/screens/DateTimeInput.js
@@ -22,7 +22,7 @@ const DateTimeInputPage = () => (
           label: 'GitHub',
         },
       ]}
-      stable
+      beta
       description="a control to input a time and date value"
       code={`<DateTimeInput
   format="12"

--- a/src/screens/Stepper.js
+++ b/src/screens/Stepper.js
@@ -19,7 +19,7 @@ const StepperPage = () => (
     <ComponentDoc
       name="Stepper"
       description="Guides users through the steps of a multi-step process, showing progress and the status of each step."
-      stable
+      beta
       code={`<Stepper
   steps={[
     { id: 'a', title: 'A', status: 'completed' },

--- a/src/screens/TimeInput.js
+++ b/src/screens/TimeInput.js
@@ -29,7 +29,7 @@ const TimeInputPage = () => (
           label: 'Github',
         },
       ]}
-      stable
+      beta
       description="A control to input a time value"
       code={`<TimeInput
   format="12"

--- a/src/screens/Wizard.js
+++ b/src/screens/Wizard.js
@@ -23,7 +23,7 @@ const WizardPage = () => (
         },
       ]}
       description="a multi-step form component"
-      stable
+      beta
       code={`<Wizard
   aria-label="Onboarding"
   title="Set up your account"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3082,9 +3082,9 @@ ejs@^3.1.10:
     jake "^10.8.5"
 
 electron-to-chromium@^1.5.402:
-  version "1.5.410"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.410.tgz#0901bccd2b2865960d8decee1653ad734a1b41de"
-  integrity sha512-Vq9DD7F4PKCKVmOoG6i1CQSYoF7IUtwTPEQjMXuqNs2S22H8HsojO9myaB81QuvvIKZaF6imSn3XAV1Su6rvXA==
+  version "1.5.411"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.411.tgz#d56c7e43f91e2b3abb53b4eecd646e20d0b18b34"
+  integrity sha512-gglkxzokjHfawpGxq75XdBV2/l3BAPzrsMs70qgaZdTW5rpV1tC4MdgJVP9fN126bODA4ZJQkn1wryEzJyQXIg==
 
 emoji-regex@^7.0.1:
   version "7.0.3"
@@ -4141,7 +4141,7 @@ grommet-theme-hpe@^5.5.0:
 
 "grommet@https://github.com/grommet/grommet/tarball/stable":
   version "2.56.1"
-  resolved "https://github.com/grommet/grommet/tarball/stable#6624b2e7ec901aa4f9282f272a05b14a751797ac"
+  resolved "https://github.com/grommet/grommet/tarball/stable#c239338af6f0c6372453a55cc029a3039c9c3f24"
   dependencies:
     "@emotion/is-prop-valid" "^1.4.0"
     grommet-icons "^4.14.0"


### PR DESCRIPTION
This adds a `beta` flag that can be used instead of the `stable` flag and changed the DateTimeInput, TimeInput, Wizard and Stepper to use that flag instead of stable since they are available in a versioned release.

<img width="933" height="353" alt="image" src="https://github.com/user-attachments/assets/78cf2ced-dc00-470d-a1ec-76f1ba442c68" />

The stable version of the message is still shown if the `stable` flag is used.